### PR TITLE
Remove Stride Parameter and Switch to Non-Overlapping Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,10 +102,10 @@ print(output)
 # Advanced configuration
 config = AnalysisConfig(
     window_size=10,
-    stride=5,
     k_neighbors=10,
     anomaly_percentile=0.05,
-    device="cuda"
+    device="cuda",
+    batch_size=64
 )
 analyzer = SemanticLogAnalyzer(config)
 result = analyzer.analyze_file_detailed(Path("app.log"))
@@ -217,10 +217,10 @@ See [Cordon's architecture](./docs/architecture.md) for full details.
 
 | Parameter | Default | CLI Flag | Description |
 |-----------|---------|----------|-------------|
-| `window_size` | 5 | `--window-size` | Lines per window |
-| `stride` | 2 | `--stride` | Lines to skip between windows |
+| `window_size` | 5 | `--window-size` | Lines per window (non-overlapping) |
 | `k_neighbors` | 5 | `--k-neighbors` | Number of neighbors for density calculation |
 | `anomaly_percentile` | 0.1 | `--anomaly-percentile` | Top N% to keep (0.1 = 10%) |
+| `batch_size` | 32 | `--batch-size` | Batch size for embedding generation |
 
 ### Backend Options
 
@@ -250,7 +250,7 @@ Run `cordon --help` for full CLI documentation.
 **For verbose system logs**, use larger-context models:
 ```bash
 # BAAI/bge-base-en-v1.5 supports 512 tokens (~8-10 verbose lines)
-cordon --model-name "BAAI/bge-base-en-v1.5" --window-size 8 --stride 4 your.log
+cordon --model-name "BAAI/bge-base-en-v1.5" --window-size 8 your.log
 ```
 
 **See [Configuration Guidelines](./docs/architecture.md#configuration-guidelines) for detailed recommendations.**
@@ -280,4 +280,4 @@ Cordon automatically chooses the best approach:
 | Memory-Mapped | 50k-500k windows | ~50-100MB | Moderate |
 | FAISS | >500k windows | ~50MB | Fast |
 
-**What's a "window"?** A window is a sliding chunk of N consecutive log lines (default: 10 lines). A 10,000-line log with window_size=10 and stride=5 creates ~2,000 windows.
+**What's a "window"?** A window is a non-overlapping chunk of N consecutive log lines (default: 5 lines). A 10,000-line log with window_size=5 creates 2,000 windows.

--- a/benchmark/evaluate.py
+++ b/benchmark/evaluate.py
@@ -830,12 +830,6 @@ def main():
         help="Cordon window size",
     )
     parser.add_argument(
-        "--stride",
-        type=int,
-        default=2,
-        help="Cordon stride",
-    )
-    parser.add_argument(
         "--k-neighbors",
         type=int,
         default=5,
@@ -985,7 +979,6 @@ def main():
     # configure Cordon
     config = AnalysisConfig(
         window_size=args.window_size,
-        stride=args.stride,
         k_neighbors=args.k_neighbors,
         anomaly_percentile=args.anomaly_percentile,
         model_name=args.model,
@@ -996,7 +989,6 @@ def main():
 
     print("Cordon Configuration:")
     print(f"  Window size: {config.window_size}")
-    print(f"  Stride: {config.stride}")
     print(f"  K-neighbors: {config.k_neighbors}")
     print(f"  Anomaly percentile: {config.anomaly_percentile:.2%}")
     print(f"  Model: {config.model_name}")
@@ -1011,7 +1003,6 @@ def main():
             "dataset": args.dataset,
             "sample_size": sample_size,
             "window_size": args.window_size,
-            "stride": args.stride,
             "k_neighbors": args.k_neighbors,
             "anomaly_percentile": args.anomaly_percentile,
             "model": args.model,

--- a/examples/library_usage.py
+++ b/examples/library_usage.py
@@ -9,10 +9,10 @@ def main() -> None:
     # create a custom configuration
     config = AnalysisConfig(
         window_size=10,
-        stride=5,
         k_neighbors=5,
         anomaly_percentile=0.1,
         model_name="all-MiniLM-L6-v2",
+        batch_size=32,
         device="cpu",  # or "cuda", "mps", or None for auto-detect
     )
 

--- a/src/cordon/cli.py
+++ b/src/cordon/cli.py
@@ -65,12 +65,6 @@ def parse_args() -> argparse.Namespace:
         help="Number of lines per window (default: 5)",
     )
     config_group.add_argument(
-        "--stride",
-        type=int,
-        default=2,
-        help="Step size for sliding window in lines (default: 2)",
-    )
-    config_group.add_argument(
         "--k-neighbors",
         type=int,
         default=5,
@@ -178,7 +172,6 @@ def main() -> None:
     try:
         config = AnalysisConfig(
             window_size=args.window_size,
-            stride=args.stride,
             k_neighbors=args.k_neighbors,
             anomaly_percentile=args.anomaly_percentile,
             model_name=args.model_name,

--- a/src/cordon/core/config.py
+++ b/src/cordon/core/config.py
@@ -7,7 +7,6 @@ class AnalysisConfig:
     """Global configuration for the analysis pipeline."""
 
     window_size: int = 5
-    stride: int = 2
     k_neighbors: int = 5
     anomaly_percentile: float = 0.1
     model_name: str = "all-MiniLM-L6-v2"
@@ -25,8 +24,6 @@ class AnalysisConfig:
         """Validate configuration parameters."""
         if self.window_size < 1:
             raise ValueError("window_size must be >= 1")
-        if self.stride < 1:
-            raise ValueError("stride must be >= 1")
         if self.k_neighbors < 1:
             raise ValueError("k_neighbors must be >= 1")
         if not 0.0 <= self.anomaly_percentile <= 1.0:

--- a/src/cordon/embedding/transformer.py
+++ b/src/cordon/embedding/transformer.py
@@ -139,9 +139,9 @@ class TransformerVectorizer:
                     f"  • Coverage: ~{coverage_pct:.0f}% of each window\n"
                     f"\n"
                     f"Recommendations:\n"
-                    f"  1. Reduce window size: --window-size {lines_that_fit} --stride {lines_that_fit // 2}\n"
+                    f"  1. Reduce window size: --window-size {lines_that_fit}\n"
                     f"  2. Use larger model: --model-name BAAI/bge-base-en-v1.5 (512 tokens)\n"
-                    f"  3. Accept partial coverage (overlapping windows still capture all lines)\n"
+                    f"  3. Accept partial coverage (non-overlapping windows may miss some context)\n"
                     f"{'=' * 70}\n",
                     UserWarning,
                     stacklevel=3,

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -56,7 +56,6 @@ class TestAnalysisConfig:
         """Test default configuration values."""
         config = AnalysisConfig()
         assert config.window_size == 5
-        assert config.stride == 2
         assert config.k_neighbors == 5
         assert config.anomaly_percentile == 0.1
         assert config.model_name == "all-MiniLM-L6-v2"
@@ -67,13 +66,11 @@ class TestAnalysisConfig:
         """Test custom configuration values."""
         config = AnalysisConfig(
             window_size=20,
-            stride=10,
             k_neighbors=10,
             anomaly_percentile=0.05,
             device="cpu",
         )
         assert config.window_size == 20
-        assert config.stride == 10
         assert config.k_neighbors == 10
         assert config.anomaly_percentile == 0.05
         assert config.device == "cpu"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -25,7 +25,6 @@ class TestIntegration:
         try:
             config = AnalysisConfig(
                 window_size=5,
-                stride=2,
                 k_neighbors=3,
                 anomaly_percentile=0.1,
                 device="cpu",

--- a/tests/test_segmentation.py
+++ b/tests/test_segmentation.py
@@ -1,5 +1,3 @@
-import pytest
-
 from cordon.core.config import AnalysisConfig
 from cordon.segmentation.windower import SlidingWindowSegmenter
 
@@ -8,24 +6,25 @@ class TestSlidingWindowSegmenter:
     """Tests for SlidingWindowSegmenter class."""
 
     def test_basic_segmentation(self) -> None:
-        """Test basic sliding window segmentation."""
-        lines = [(1, "line1"), (2, "line2"), (3, "line3"), (4, "line4"), (5, "line5")]
-        config = AnalysisConfig(window_size=3, stride=1)
+        """Test basic non-overlapping window segmentation."""
+        lines = [(1, "line1"), (2, "line2"), (3, "line3"), (4, "line4"), (5, "line5"), (6, "line6")]
+        config = AnalysisConfig(window_size=3)
 
         segmenter = SlidingWindowSegmenter()
         windows = list(segmenter.segment(iter(lines), config))
 
-        assert len(windows) == 4
+        assert len(windows) == 2
         assert windows[0].start_line == 1
         assert windows[0].end_line == 3
         assert windows[0].content == "line1\nline2\nline3"
-        assert windows[1].start_line == 2
-        assert windows[1].end_line == 4
+        assert windows[1].start_line == 4
+        assert windows[1].end_line == 6
+        assert windows[1].content == "line4\nline5\nline6"
 
     def test_non_overlapping_windows(self) -> None:
-        """Test segmentation with stride equal to window size."""
+        """Test segmentation creates non-overlapping windows."""
         lines = [(1, "line1"), (2, "line2"), (3, "line3"), (4, "line4")]
-        config = AnalysisConfig(window_size=2, stride=2)
+        config = AnalysisConfig(window_size=2)
 
         segmenter = SlidingWindowSegmenter()
         windows = list(segmenter.segment(iter(lines), config))
@@ -37,7 +36,7 @@ class TestSlidingWindowSegmenter:
     def test_partial_final_window(self) -> None:
         """Test that partial final window is included."""
         lines = [(1, "line1"), (2, "line2"), (3, "line3")]
-        config = AnalysisConfig(window_size=2, stride=2)
+        config = AnalysisConfig(window_size=2)
 
         segmenter = SlidingWindowSegmenter()
         windows = list(segmenter.segment(iter(lines), config))
@@ -51,7 +50,7 @@ class TestSlidingWindowSegmenter:
     def test_empty_input(self) -> None:
         """Test segmentation with empty input."""
         lines: list[tuple[int, str]] = []
-        config = AnalysisConfig(window_size=3, stride=1)
+        config = AnalysisConfig(window_size=3)
 
         segmenter = SlidingWindowSegmenter()
         windows = list(segmenter.segment(iter(lines), config))
@@ -61,7 +60,7 @@ class TestSlidingWindowSegmenter:
     def test_single_line(self) -> None:
         """Test segmentation with single line."""
         lines = [(1, "line1")]
-        config = AnalysisConfig(window_size=3, stride=1)
+        config = AnalysisConfig(window_size=3)
 
         segmenter = SlidingWindowSegmenter()
         windows = list(segmenter.segment(iter(lines), config))
@@ -71,19 +70,22 @@ class TestSlidingWindowSegmenter:
         assert windows[0].start_line == 1
         assert windows[0].end_line == 1
 
-    def test_stride_greater_than_window_size_warns(self) -> None:
-        """Test that stride > window_size issues a warning."""
-        lines = [(1, "line1"), (2, "line2"), (3, "line3"), (4, "line4")]
-        config = AnalysisConfig(window_size=2, stride=3)
+    def test_exact_multiple_windows(self) -> None:
+        """Test segmentation when lines are exact multiple of window size."""
+        lines = [(1, "line1"), (2, "line2"), (3, "line3"), (4, "line4"), (5, "line5"), (6, "line6")]
+        config = AnalysisConfig(window_size=3)
 
         segmenter = SlidingWindowSegmenter()
-        with pytest.warns(UserWarning, match="creates gaps"):
-            list(segmenter.segment(iter(lines), config))
+        windows = list(segmenter.segment(iter(lines), config))
+
+        assert len(windows) == 2
+        assert windows[0].content == "line1\nline2\nline3"
+        assert windows[1].content == "line4\nline5\nline6"
 
     def test_window_ids_incremental(self) -> None:
         """Test that window IDs are incremental."""
         lines = [(1, "line1"), (2, "line2"), (3, "line3"), (4, "line4")]
-        config = AnalysisConfig(window_size=2, stride=1)
+        config = AnalysisConfig(window_size=2)
 
         segmenter = SlidingWindowSegmenter()
         windows = list(segmenter.segment(iter(lines), config))


### PR DESCRIPTION
Removed the stride parameter from the entire codebase and switched to non-overlapping windows. The sliding window approach with overlap was found to normalize anomaly scores and hide anomalies by spreading them across multiple windows.