### PR TITLE
Remove FAISS support and related documentation

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -16,7 +16,7 @@ RUN pip install --no-cache-dir uv
 COPY pyproject.toml README.md LICENSE ./
 COPY src/ ./src/
 
-RUN uv pip install --system -e ".[llama-cpp,faiss-cpu]"
+RUN uv pip install --system -e ".[llama-cpp]"
 
 RUN CMAKE_ARGS="-DGGML_VULKAN=on" \
     uv pip install --system --no-cache-dir llama-cpp-python

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install install-dev install-faiss install-faiss-gpu test test-verbose coverage lint format typecheck pre-commit clean clean-all container-build container-run
+.PHONY: help install install-dev test test-verbose coverage lint format typecheck pre-commit clean clean-all container-build container-run
 
 # default target - show help
 help:
@@ -7,8 +7,6 @@ help:
 	@echo "Available targets:"
 	@echo "  make install         Install package in development mode"
 	@echo "  make install-dev     Install with development dependencies"
-	@echo "  make install-faiss   Install with FAISS CPU support (better performance)"
-	@echo "  make install-faiss-gpu Install with FAISS GPU support (CUDA required)"
 	@echo ""
 	@echo "  make test            Run all tests"
 	@echo "  make test-verbose    Run tests with verbose output"
@@ -35,18 +33,12 @@ install:
 install-dev:
 	pip install -e ".[dev]"
 
-install-faiss:
-	pip install -e ".[faiss-cpu]"
-
-install-faiss-gpu:
-	pip install -e ".[faiss-gpu]"
-
 # testing targets
 test:
-	OMP_NUM_THREADS=1 pytest tests/ --no-cov
+	OMP_NUM_THREADS=1 pytest tests/ --override-ini="addopts="
 
 test-verbose:
-	OMP_NUM_THREADS=1 pytest tests/ -v --no-cov
+	OMP_NUM_THREADS=1 pytest tests/ -v --override-ini="addopts="
 
 coverage:
 	OMP_NUM_THREADS=1 pytest tests/ --cov=cordon --cov-report=term-missing --cov-report=html

--- a/README.md
+++ b/README.md
@@ -52,13 +52,6 @@ For llama.cpp backend (GPU acceleration in containers):
 uv pip install -e ".[llama-cpp]"
 ```
 
-For FAISS support (better performance on large logs):
-
-```bash
-uv pip install -e ".[faiss-cpu]"  # CPU
-uv pip install -e ".[faiss-gpu]"  # GPU
-```
-
 ### Container Installation
 
 ```bash
@@ -81,11 +74,8 @@ cordon app.log error.log
 # With options
 cordon --window-size 10 --k-neighbors 10 --anomaly-percentile 0.05 app.log
 
-# With FAISS for large logs
-cordon --use-faiss large.log
-
 # llama.cpp backend (for containers)
-cordon --backend llama-cpp --use-faiss system.log
+cordon --backend llama-cpp system.log
 ```
 
 ### Python Library
@@ -129,13 +119,13 @@ Best for container deployments with GPU acceleration via Vulkan.
 
 ```bash
 # Auto-downloads model on first run
-cordon --backend llama-cpp --use-faiss system.log
+cordon --backend llama-cpp system.log
 
 # With GPU acceleration
-cordon --backend llama-cpp --use-faiss --n-gpu-layers 10 system.log
+cordon --backend llama-cpp --n-gpu-layers 10 system.log
 
 # Custom model
-cordon --backend llama-cpp --use-faiss --model-path ./model.gguf system.log
+cordon --backend llama-cpp --model-path ./model.gguf system.log
 ```
 
 See [llama.cpp Guide](./docs/llama-cpp.md) for details on models, performance, and GPU setup.
@@ -163,7 +153,7 @@ make container-run DIR=/path/to/logs ARGS="/logs/system.log"
 
 # With GPU (requires Podman with libkrun)
 podman run --device /dev/dri -v /path/to/logs:/logs:Z ghcr.io/calebevans/cordon:latest \
-  --backend llama-cpp --use-faiss --n-gpu-layers 10 /logs/system.log
+  --backend llama-cpp --n-gpu-layers 10 /logs/system.log
 ```
 
 See [Container Guide](./docs/CONTAINER.md) for full details.
@@ -231,7 +221,6 @@ See [Cordon's architecture](./docs/architecture.md) for full details.
 | `device` | Auto | `--device` | Device (cuda/mps/cpu) |
 | `model_path` | None | `--model-path` | GGUF model path (llama-cpp) |
 | `n_gpu_layers` | 0 | `--n-gpu-layers` | GPU layers (llama-cpp) |
-| `use_faiss` | False | `--use-faiss` | Use FAISS for large logs |
 
 Run `cordon --help` for full CLI documentation.
 
@@ -277,7 +266,6 @@ Cordon automatically chooses the best approach:
 | Strategy | When | RAM Usage | Speed |
 |----------|------|-----------|-------|
 | In-Memory | <50k windows | ~200-500MB | Fastest |
-| Memory-Mapped | 50k-500k windows | ~50-100MB | Moderate |
-| FAISS | >500k windows | ~50MB | Fast |
+| Memory-Mapped | ≥50k windows | ~50-100MB | Moderate |
 
 **What's a "window"?** A window is a non-overlapping chunk of N consecutive log lines (default: 5 lines). A 10,000-line log with window_size=5 creates 2,000 windows.

--- a/benchmark/evaluate.py
+++ b/benchmark/evaluate.py
@@ -883,11 +883,6 @@ def main():
         help="Custom name for run directory (default: auto timestamp)",
     )
     parser.add_argument(
-        "--use-faiss",
-        action="store_true",
-        help="Use FAISS for k-NN (better performance on large logs)",
-    )
-    parser.add_argument(
         "--batch-size",
         type=int,
         default=32,
@@ -984,7 +979,6 @@ def main():
         model_name=args.model,
         device=args.device,
         batch_size=args.batch_size,
-        use_faiss_threshold=1 if args.use_faiss else None,
     )
 
     print("Cordon Configuration:")
@@ -994,7 +988,6 @@ def main():
     print(f"  Model: {config.model_name}")
     print(f"  Device: {config.device or 'auto-detect'}")
     print(f"  Batch size: {config.batch_size}")
-    print(f"  Use FAISS: {args.use_faiss}")
     print()
 
     # save parameters if output directory specified (skip if resuming)
@@ -1008,7 +1001,6 @@ def main():
             "model": args.model,
             "device": args.device or "auto-detect",
             "batch_size": args.batch_size,
-            "use_faiss": args.use_faiss,
             "runs": args.runs,
             "seed": args.seed,
             "timestamp": datetime.now().isoformat(),

--- a/benchmark/results/README.md
+++ b/benchmark/results/README.md
@@ -311,7 +311,6 @@ Traditional line-level F1 scores (observed: 5-8%) are low by design. Cordon igno
 
 **All Tests:**
 - **Device:** CUDA (GPU acceleration)
-- **FAISS:** Disabled (exact k-NN)
 - **Seed:** 42 (reproducible sampling)
 - **Runs:** 10 per configuration
 

--- a/docs/CONTAINER.md
+++ b/docs/CONTAINER.md
@@ -94,13 +94,11 @@ podman run -v $(pwd)/logs:/logs cordon:latest \
 # CPU-only (uses pre-cached model)
 podman run -v $(pwd)/logs:/logs cordon:latest \
   --backend llama-cpp \
-  --use-faiss \
   /logs/system.log
 
 # With GPU (requires libkrun on macOS)
 podman run --device /dev/dri -v $(pwd)/logs:/logs cordon:latest \
   --backend llama-cpp \
-  --use-faiss \
   --n-gpu-layers 10 \
   /logs/system.log
 ```
@@ -145,7 +143,7 @@ podman machine start
 # Note: GPU passthrough is enabled by default with libkrun
 # The --device /dev/dri flag is optional
 podman run -v $(pwd)/logs:/logs cordon:latest \
-  --backend llama-cpp --use-faiss --n-gpu-layers 10 /logs/system.log
+  --backend llama-cpp --n-gpu-layers 10 /logs/system.log
 ```
 
 ### Linux with NVIDIA
@@ -157,7 +155,7 @@ sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml
 # Run with CUDA
 podman run --hooks-dir=/usr/share/containers/oci/hooks.d/ \
   -v $(pwd)/logs:/logs:z cordon:latest \
-  --backend llama-cpp --use-faiss --n-gpu-layers 10 /logs/system.log
+  --backend llama-cpp --n-gpu-layers 10 /logs/system.log
 ```
 
 ### Linux with AMD/Intel
@@ -169,7 +167,7 @@ sudo dnf install mesa-vulkan-drivers vulkan-tools      # Fedora/RHEL
 
 # Run with Vulkan
 podman run --device /dev/dri -v $(pwd)/logs:/logs cordon:latest \
-  --backend llama-cpp --use-faiss --n-gpu-layers 10 /logs/system.log
+  --backend llama-cpp --n-gpu-layers 10 /logs/system.log
 ```
 
 ## SELinux Volume Labels

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -252,13 +252,11 @@ Merged block: lines 10-30 (score=max(0.15, 0.18, 0.12) = 0.18)
 1. **Lazy loading**: Read log lines on-demand
 2. **Streaming embeddings**: Process in batches, don't store all at once
 3. **Memory-mapped arrays**: Store embeddings on disk for huge logs
-4. **FAISS indexing**: Approximate k-NN for millions of windows
 
 **Automatic scaling:**
 ```python
 < 50K windows:  In-memory NumPy arrays (fastest)
 ≥ 50K windows:  Memory-mapped arrays (RAM-efficient, auto-enabled)
-Optional:       FAISS approximate search (for very large logs, must be installed)
 ```
 ### Batching Strategy
 

--- a/docs/llama-cpp.md
+++ b/docs/llama-cpp.md
@@ -70,17 +70,15 @@ The default GGUF model is automatically downloaded on first use:
 
 ```bash
 # CPU-only
-cordon --backend llama-cpp --use-faiss /path/to/logfile.log
+cordon --backend llama-cpp /path/to/logfile.log
 
 # GPU-accelerated (offload 10 layers)
 cordon --backend llama-cpp \
-    --use-faiss \
     --n-gpu-layers 10 \
     /path/to/logfile.log
 
 # All GPU layers (maximum acceleration)
 cordon --backend llama-cpp \
-    --use-faiss \
     --n-gpu-layers -1 \
     /path/to/logfile.log
 ```
@@ -89,7 +87,6 @@ cordon --backend llama-cpp \
 
 ```bash
 cordon --backend llama-cpp \
-    --use-faiss \
     --model-path ~/models/custom.gguf \
     --n-gpu-layers 10 \
     /path/to/logfile.log
@@ -99,7 +96,6 @@ cordon --backend llama-cpp \
 
 ```bash
 cordon --backend llama-cpp \
-    --use-faiss \
     --n-gpu-layers 10 \           # GPU layer offloading
     --n-ctx 2048 \                # Context size
     --n-threads 8 \               # CPU threads
@@ -124,7 +120,6 @@ make container-build
 # The --device /dev/dri flag is optional
 podman run -v ./logs:/logs cordon:latest \
     --backend llama-cpp \
-    --use-faiss \
     --n-gpu-layers 10 \
     /logs/system.log
 
@@ -132,14 +127,12 @@ podman run -v ./logs:/logs cordon:latest \
 podman run --hooks-dir=/usr/share/containers/oci/hooks.d/ \
     -v ./logs:/logs:z cordon:latest \
     --backend llama-cpp \
-    --use-faiss \
     --n-gpu-layers 10 \
     /logs/system.log
 
 # Linux with AMD/Intel (Vulkan)
 podman run --device /dev/dri -v ./logs:/logs:z cordon:latest \
     --backend llama-cpp \
-    --use-faiss \
     --n-gpu-layers 10 \
     /logs/system.log
 ```
@@ -161,5 +154,5 @@ podman run --device /dev/dri -v ./logs:/logs:z cordon:latest \
 wget https://huggingface.co/second-state/All-MiniLM-L6-v2-Embedding-GGUF/resolve/main/all-MiniLM-L6-v2-Q4_K_M.gguf
 
 # Use with Cordon
-cordon --backend llama-cpp --use-faiss --model-path ./all-MiniLM-L6-v2-Q4_K_M.gguf logs/system.log
+cordon --backend llama-cpp --model-path ./all-MiniLM-L6-v2-Q4_K_M.gguf logs/system.log
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,12 +39,6 @@ llama-cpp = [
     "llama-cpp-python>=0.3.0",
     "huggingface-hub>=0.20.0",
 ]
-faiss-cpu = [
-    "faiss-cpu>=1.7.0",
-]
-faiss-gpu = [
-    "faiss-gpu>=1.7.0",
-]
 
 [build-system]
 requires = ["hatchling"]
@@ -74,10 +68,6 @@ ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = "sklearn.*"
-ignore_missing_imports = true
-
-[[tool.mypy.overrides]]
-module = "faiss.*"
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]

--- a/src/cordon/cli.py
+++ b/src/cordon/cli.py
@@ -95,11 +95,6 @@ def parse_args() -> argparse.Namespace:
         default=None,
         help="Device for model inference (default: auto-detect)",
     )
-    config_group.add_argument(
-        "--use-faiss",
-        action="store_true",
-        help="Use FAISS for faster k-NN search on large logs",
-    )
 
     # output options
     output_group = parser.add_argument_group("output options")
@@ -177,7 +172,6 @@ def main() -> None:
             model_name=args.model_name,
             batch_size=args.batch_size,
             device=args.device,
-            use_faiss_threshold=0 if args.use_faiss else None,
             backend=args.backend,
             model_path=str(args.model_path) if args.model_path else None,
             n_gpu_layers=args.n_gpu_layers,

--- a/src/cordon/core/config.py
+++ b/src/cordon/core/config.py
@@ -13,7 +13,6 @@ class AnalysisConfig:
     batch_size: int = 32
     device: str | None = None
     use_mmap_threshold: int | None = 50000  # switch to mmap at 50k windows
-    use_faiss_threshold: int | None = None  # FAISS disabled by default
     backend: str = "sentence-transformers"  # or "llama-cpp"
     model_path: str | None = None  # GGUF model file path
     n_ctx: int = 2048  # llama.cpp context size


### PR DESCRIPTION
Remove FAISS because it wasn't providing the intended benefits. It hogged vRAM on the GPU, and using it on CPU didn't speed up much.