### PR TITLE
Introduce anomaly range filtering mode and enhance documentation

### DIFF
--- a/examples/library_usage.py
+++ b/examples/library_usage.py
@@ -6,7 +6,7 @@ from cordon import AnalysisConfig, SemanticLogAnalyzer
 
 def main() -> None:
     """Demonstrate basic library usage."""
-    # create a custom configuration
+    # Example 1: Percentile mode (default) - keep top 10% most anomalous
     config = AnalysisConfig(
         window_size=10,
         k_neighbors=5,
@@ -22,7 +22,7 @@ def main() -> None:
     # analyze a log file (simple API)
     log_path = Path("sample.log")
     output = analyzer.analyze_file(log_path)
-    print("Anomalous blocks:")
+    print("Anomalous blocks (percentile mode):")
     print(output)
 
     # or use detailed API for statistics
@@ -36,6 +36,22 @@ def main() -> None:
     print(f"  Max: {result.score_distribution['max']:.4f}")
     print("\nOutput:")
     print(result.output)
+
+    # Example 2: Range mode - exclude top 5%, keep next 10%
+    print("\n" + "=" * 60)
+    print("Range mode: exclude top 5%, keep next 10%")
+    print("=" * 60)
+    config_range = AnalysisConfig(
+        window_size=10,
+        k_neighbors=5,
+        anomaly_range_min=0.05,  # exclude top 5% (most extreme)
+        anomaly_range_max=0.15,  # include up to 15% (keep next 10%)
+        device="cpu",
+    )
+    analyzer_range = SemanticLogAnalyzer(config_range)
+    result_range = analyzer_range.analyze_file_detailed(log_path)
+    print(f"  Significant windows: {result_range.significant_windows}")
+    print("  (Excludes the most extreme anomalies, focuses on moderate ones)")
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cordon"
-version = "0.2.0"
+version = "0.2.1"
 description = "Semantic anomaly detection for system log files"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/cordon/core/config.py
+++ b/src/cordon/core/config.py
@@ -9,6 +9,12 @@ class AnalysisConfig:
     window_size: int = 4
     k_neighbors: int = 5
     anomaly_percentile: float = 0.1
+    anomaly_range_min: float | None = (
+        None  # Lower bound for range mode (e.g., 0.05 = exclude top 5%)
+    )
+    anomaly_range_max: float | None = (
+        None  # Upper bound for range mode (e.g., 0.15 = include up to 15%)
+    )
     model_name: str = "all-MiniLM-L6-v2"
     batch_size: int = 32
     device: str | None = None
@@ -27,6 +33,24 @@ class AnalysisConfig:
             raise ValueError("k_neighbors must be >= 1")
         if not 0.0 <= self.anomaly_percentile <= 1.0:
             raise ValueError("anomaly_percentile must be between 0.0 and 1.0")
+
+        # Validate anomaly range parameters
+        if (self.anomaly_range_min is None) != (self.anomaly_range_max is None):
+            raise ValueError(
+                "anomaly_range_min and anomaly_range_max must both be set or both be None"
+            )
+
+        if self.anomaly_range_min is not None:
+            # Type narrowing: if min is not None, max is also not None (checked above)
+            assert self.anomaly_range_max is not None
+
+            if not 0.0 <= self.anomaly_range_min <= 1.0:
+                raise ValueError("anomaly_range_min must be between 0.0 and 1.0")
+            if not 0.0 <= self.anomaly_range_max <= 1.0:
+                raise ValueError("anomaly_range_max must be between 0.0 and 1.0")
+            if self.anomaly_range_min >= self.anomaly_range_max:
+                raise ValueError("anomaly_range_min must be less than anomaly_range_max")
+
         if self.batch_size < 1:
             raise ValueError("batch_size must be >= 1")
         if self.scoring_batch_size is not None and self.scoring_batch_size < 1:


### PR DESCRIPTION
- Added support for a new anomaly range filtering mode in the analysis configuration, allowing users to exclude the top X% of anomalies and retain the next Y%.
- Updated the CLI to accept `--anomaly-range` for specifying the percentile range.