### PR TITLE
Unify scorer, extract device detection, and optimize pipeline memory

### DIFF
--- a/src/cordon/analysis/scorer.py
+++ b/src/cordon/analysis/scorer.py
@@ -166,7 +166,6 @@ class DensityAnomalyScorer:
                     ScoredWindow(
                         window=windows[global_idx],
                         score=float(batch_scores[local_idx]),
-                        embedding=embeddings_np[global_idx],
                     )
                 )
 
@@ -196,8 +195,8 @@ class DensityAnomalyScorer:
             return []
 
         if len(embedded_windows) == 1:
-            window, embedding = embedded_windows[0]
-            return [ScoredWindow(window=window, score=0.0, embedding=embedding)]
+            window, _ = embedded_windows[0]
+            return [ScoredWindow(window=window, score=0.0)]
 
         from cordon.core.device import detect_device
 

--- a/src/cordon/analysis/scorer.py
+++ b/src/cordon/analysis/scorer.py
@@ -1,124 +1,125 @@
+"""Density anomaly scorer using k-NN cosine distance."""
+
+import logging
 from collections.abc import Sequence
 from typing import Any
 
 import numpy as np
 import numpy.typing as npt
-import torch
-from tqdm import tqdm
 
 from cordon.core.config import AnalysisConfig
-from cordon.core.device import detect_device
 from cordon.core.types import ScoredWindow, TextWindow
 
-# Constants
+logger = logging.getLogger(__name__)
+
 _SCORING_PROGRESS_DESC = "Scoring embeddings   "
+
+_CPU_DEFAULT_BATCH = 10_000
+_MIN_BATCH = 1_000
+_MAX_GPU_BATCH = 100_000
+_MAX_MPS_BATCH = 50_000
+_GPU_MEMORY_FRACTION = 0.1
+_MPS_ASSUMED_MEMORY_GB = 1.0
+_GPU_TARGET_MEMORY_GB = 1
+_CPU_TARGET_MEMORY_GB = 2
 
 
 class DensityAnomalyScorer:
     """Calculate significance scores using k-NN cosine distance.
 
-    This scorer uses the average distance to k nearest neighbors as a measure
-    of how anomalous each window is. Higher distances
-    indicate more anomalous content.
-
-    For large datasets, automatically switches to memory-mapped storage to
-    reduce RAM usage.
+    Uses the average distance to k nearest neighbors as a measure
+    of how anomalous each window is. Higher distances indicate more
+    anomalous content.
     """
 
     def _calculate_n_neighbors(self, config: AnalysisConfig, n_samples: int) -> int:
         """Calculate the number of neighbors to use for k-NN.
 
         Args:
-            config: Analysis configuration with k_neighbors setting
-            n_samples: Total number of samples in the dataset
+            config: Analysis configuration with k_neighbors setting.
+            n_samples: Total number of samples in the dataset.
 
         Returns:
-            Number of neighbors to use (k+1 for self, capped at n_samples)
+            Number of neighbors to use (k+1 for self, capped at n_samples).
         """
-        num_neighbors = config.k_neighbors
-        return min(num_neighbors + 1, n_samples)
+        return min(config.k_neighbors + 1, n_samples)
 
     def _auto_detect_batch_size(self, n_samples: int, device: str) -> int:
         """Auto-detect optimal batch size based on available memory.
 
         Args:
-            n_samples: Total number of samples in the dataset
-            device: Device string ('cuda', 'mps', or 'cpu')
+            n_samples: Total number of samples in the dataset.
+            device: Device string ('cuda', 'mps', or 'cpu').
 
         Returns:
-            Optimal batch size for scoring
+            Optimal batch size for scoring.
         """
         if device == "cpu":
-            # CPU: use conservative default
-            return 10000
+            return _CPU_DEFAULT_BATCH
 
         if device == "cuda":
             try:
-                # Get available GPU memory
+                import torch
+
                 props = torch.cuda.get_device_properties(0)
                 total_memory_gb = props.total_memory / 1024**3
-
-                # Target: use ~10% of GPU memory for distance matrix
-                # distance_matrix = batch_size × n_samples × 4 bytes (float32)
-                target_memory_gb = total_memory_gb * 0.1
+                target_memory_gb = total_memory_gb * _GPU_MEMORY_FRACTION
                 batch_size = int((target_memory_gb * 1024**3) / (n_samples * 4))
-
-                # reasonable bounds: 1k to 100k
-                return max(1000, min(batch_size, 100000))
+                return max(_MIN_BATCH, min(batch_size, _MAX_GPU_BATCH))
             except Exception:
-                return 10000
+                logger.warning(
+                    "Failed to auto-detect GPU batch size, using default",
+                    exc_info=True,
+                )
+                return _CPU_DEFAULT_BATCH
 
         if device == "mps":
-            # MPS: conservative estimate (Apple doesn't expose memory info easily)
-            # assume ~10GB available, use similar calculation
-            target_memory_gb = 1.0  # 10% of assumed 10GB
-            batch_size = int((target_memory_gb * 1024**3) / (n_samples * 4))
-            return max(1000, min(batch_size, 50000))
+            batch_size = int((_MPS_ASSUMED_MEMORY_GB * 1024**3) / (n_samples * 4))
+            return max(_MIN_BATCH, min(batch_size, _MAX_MPS_BATCH))
 
-        # fallback
-        return 10000
+        return _CPU_DEFAULT_BATCH
 
-    def _score_windows_gpu(
+    def _score_windows(
         self,
         embedded_windows: Sequence[tuple[TextWindow, npt.NDArray[np.floating[Any]]]],
         config: AnalysisConfig,
         device: str,
     ) -> list[ScoredWindow]:
-        """Score windows using GPU acceleration (CUDA or MPS).
+        """Score windows using k-NN density on the specified device.
 
         Args:
-            embedded_windows: Sequence of (window, embedding) pairs
-            config: Analysis configuration
-            device: GPU device ('cuda' or 'mps')
+            embedded_windows: Sequence of (window, embedding) pairs.
+            config: Analysis configuration.
+            device: PyTorch device string ('cuda', 'mps', or 'cpu').
 
         Returns:
-            List of scored windows
+            List of scored windows with anomaly scores.
         """
-        # extract windows and embeddings
+        import torch
+        import torch.nn.functional as F
+        from tqdm import tqdm
+
         windows = [window for window, _ in embedded_windows]
         embeddings_np = np.array([embedding for _, embedding in embedded_windows], dtype=np.float32)
         n_samples = len(embeddings_np)
 
-        # convert to PyTorch tensor on GPU
         embeddings_tensor = torch.from_numpy(embeddings_np).to(device)
+        embeddings_tensor = F.normalize(embeddings_tensor, p=2, dim=1)
 
-        # calculate number of neighbors
         n_neighbors = self._calculate_n_neighbors(config, n_samples)
 
-        # determine batch size (auto-detect if not specified)
         if config.scoring_batch_size is None:
             query_batch_size = self._auto_detect_batch_size(n_samples, device)
         else:
             query_batch_size = config.scoring_batch_size
 
-        scored_windows = []
-
-        # compute chunk size for similarity calculation to avoid OOM
-        # aim for ~1GB of similarity matrix per chunk
-        bytes_per_element = 4  # float32
-        target_memory_gb = 1
+        bytes_per_element = 4
+        target_memory_gb = _GPU_TARGET_MEMORY_GB if device != "cpu" else _CPU_TARGET_MEMORY_GB
         chunk_size = int((target_memory_gb * 1024**3) / (query_batch_size * bytes_per_element))
-        chunk_size = min(chunk_size, n_samples)  # don't exceed total samples
+        chunk_size = min(chunk_size, n_samples)
+        chunk_size = max(chunk_size, 1)
+
+        scored_windows: list[ScoredWindow] = []
 
         for batch_start in tqdm(
             range(0, n_samples, query_batch_size),
@@ -130,145 +131,47 @@ class DensityAnomalyScorer:
             batch_embeddings = embeddings_tensor[batch_start:batch_end]
             batch_size_actual = batch_end - batch_start
 
-            # track top-k distances across chunks (more memory efficient)
-            # initialize with large values
             top_k_distances = torch.full(
-                (batch_size_actual, n_neighbors), float("inf"), dtype=torch.float32, device=device
+                (batch_size_actual, n_neighbors),
+                float("inf"),
+                dtype=torch.float32,
+                device=device,
             )
 
-            # compute similarities in chunks and maintain top-k
             for chunk_start in range(0, n_samples, chunk_size):
                 chunk_end = min(chunk_start + chunk_size, n_samples)
                 chunk_embeddings = embeddings_tensor[chunk_start:chunk_end]
 
-                # compute cosine similarity for this chunk
                 similarities = torch.mm(batch_embeddings, chunk_embeddings.T)
-
-                # convert to distance (clamp to handle floating point errors)
-                # cosine similarity can be slightly > 1.0 due to floating point precision
+                # Clamp to handle floating point errors where cosine > 1.0
                 chunk_distances = torch.clamp(1.0 - similarities, min=0.0, max=2.0)
 
-                # combine with existing top-k
-                combined_distances = torch.cat([top_k_distances, chunk_distances], dim=1)
-
-                # find new top-k from combined
+                chunk_topk, _ = torch.topk(
+                    chunk_distances,
+                    k=min(n_neighbors, chunk_distances.shape[1]),
+                    dim=1,
+                    largest=False,
+                    sorted=True,
+                )
+                combined = torch.cat([top_k_distances, chunk_topk], dim=1)
                 top_k_distances, _ = torch.topk(
-                    combined_distances, k=n_neighbors, dim=1, largest=False, sorted=True
+                    combined, k=n_neighbors, dim=1, largest=False, sorted=True
                 )
 
-            # move results back to CPU for processing
-            neighbor_distances_cpu = top_k_distances.cpu().numpy()
+            neighbor_distances_np = top_k_distances.cpu().numpy()
+            batch_scores = np.maximum(neighbor_distances_np[:, 1:].mean(axis=1), 0.0)
 
-            # calculate scores for this batch
             for local_idx, global_idx in enumerate(range(batch_start, batch_end)):
-                window = windows[global_idx]
-                embedding = embeddings_np[global_idx]
-
-                # skip first distance (self = 0) and take mean of remaining
-                neighbor_dists = neighbor_distances_cpu[local_idx][1:]
-                score = float(np.mean(neighbor_dists))
-
-                # ensure score is non-negative (handle any remaining floating point errors)
-                score = max(0.0, score)
-
-                scored_windows.append(ScoredWindow(window=window, score=score, embedding=embedding))
-
-            # clear GPU cache after each batch for memory management
-            if device == "cuda":
-                torch.cuda.empty_cache()
-            # MPS doesn't have empty_cache equivalent
-
-        return scored_windows
-
-    def _score_windows_cpu_pytorch(
-        self,
-        embedded_windows: Sequence[tuple[TextWindow, npt.NDArray[np.floating[Any]]]],
-        config: AnalysisConfig,
-    ) -> list[ScoredWindow]:
-        """Score windows using PyTorch on CPU.
-
-        Args:
-            embedded_windows: Sequence of (window, embedding) pairs
-            config: Analysis configuration
-
-        Returns:
-            List of scored windows
-        """
-        # extract windows and embeddings
-        windows = [window for window, _ in embedded_windows]
-        embeddings_np = np.array([embedding for _, embedding in embedded_windows], dtype=np.float32)
-        n_samples = len(embeddings_np)
-
-        # convert to PyTorch tensor on CPU
-        embeddings_tensor = torch.from_numpy(embeddings_np)
-
-        # calculate number of neighbors
-        n_neighbors = self._calculate_n_neighbors(config, n_samples)
-
-        # determine batch size (auto-detect if not specified)
-        if config.scoring_batch_size is None:
-            query_batch_size = self._auto_detect_batch_size(n_samples, "cpu")
-        else:
-            query_batch_size = config.scoring_batch_size
-
-        scored_windows = []
-
-        # compute chunk size for similarity calculation to avoid OOM on CPU
-        # aim for ~2GB of similarity matrix per chunk on CPU (more than GPU)
-        bytes_per_element = 4  # float32
-        target_memory_gb = 2
-        chunk_size = int((target_memory_gb * 1024**3) / (query_batch_size * bytes_per_element))
-        chunk_size = min(chunk_size, n_samples)  # don't exceed total samples
-
-        for batch_start in tqdm(
-            range(0, n_samples, query_batch_size),
-            desc=_SCORING_PROGRESS_DESC,
-            unit="batch",
-            total=(n_samples + query_batch_size - 1) // query_batch_size,
-        ):
-            batch_end = min(batch_start + query_batch_size, n_samples)
-            batch_embeddings = embeddings_tensor[batch_start:batch_end]
-            batch_size_actual = batch_end - batch_start
-
-            # track top-k distances across chunks (more memory efficient)
-            # initialize with large values
-            top_k_distances = torch.full(
-                (batch_size_actual, n_neighbors), float("inf"), dtype=torch.float32
-            )
-
-            # compute similarities in chunks and maintain top-k
-            for chunk_start in range(0, n_samples, chunk_size):
-                chunk_end = min(chunk_start + chunk_size, n_samples)
-                chunk_embeddings = embeddings_tensor[chunk_start:chunk_end]
-
-                # compute cosine similarity for this chunk
-                similarities = torch.mm(batch_embeddings, chunk_embeddings.T)
-
-                # convert to distance (clamp to handle floating point errors)
-                # cosine similarity can be slightly > 1.0 due to floating point precision
-                chunk_distances = torch.clamp(1.0 - similarities, min=0.0, max=2.0)
-
-                # combine with existing top-k
-                combined_distances = torch.cat([top_k_distances, chunk_distances], dim=1)
-
-                # find new top-k from combined
-                top_k_distances, _ = torch.topk(
-                    combined_distances, k=n_neighbors, dim=1, largest=False, sorted=True
+                scored_windows.append(
+                    ScoredWindow(
+                        window=windows[global_idx],
+                        score=float(batch_scores[local_idx]),
+                        embedding=embeddings_np[global_idx],
+                    )
                 )
 
-            # convert to numpy for processing
-            neighbor_distances_np = top_k_distances.numpy()
-
-            # calculate scores for this batch
-            for local_idx, global_idx in enumerate(range(batch_start, batch_end)):
-                window = windows[global_idx]
-                embedding = embeddings_np[global_idx]
-
-                # skip first distance (self = 0) and take mean of remaining
-                neighbor_dists = neighbor_distances_np[local_idx][1:]
-                score = float(np.mean(neighbor_dists))
-
-                scored_windows.append(ScoredWindow(window=window, score=score, embedding=embedding))
+        if device == "cuda":
+            torch.cuda.empty_cache()
 
         return scored_windows
 
@@ -279,31 +182,24 @@ class DensityAnomalyScorer:
     ) -> list[ScoredWindow]:
         """Score windows based on k-NN density.
 
-        This is the central routing function that selects the appropriate
-        scoring implementation based on available hardware and configuration.
+        Routes to the unified scoring implementation after detecting the
+        best available compute device.
 
         Args:
-            embedded_windows: Sequence of (window, embedding) pairs
-            config: Analysis configuration with k_neighbors setting
+            embedded_windows: Sequence of (window, embedding) pairs.
+            config: Analysis configuration with k_neighbors setting.
 
         Returns:
-            List of scored windows with anomaly scores
+            List of scored windows with anomaly scores.
         """
         if not embedded_windows:
             return []
 
-        # single window
         if len(embedded_windows) == 1:
             window, embedding = embedded_windows[0]
             return [ScoredWindow(window=window, score=0.0, embedding=embedding)]
 
-        # detect best available device
-        device = detect_device(config.device)
+        from cordon.core.device import detect_device
 
-        # route to appropriate PyTorch implementation
-        if device in ("cuda", "mps"):
-            # use GPU-accelerated implementation
-            return self._score_windows_gpu(embedded_windows, config, device)
-        else:
-            # use PyTorch CPU implementation
-            return self._score_windows_cpu_pytorch(embedded_windows, config)
+        device = detect_device(config.device)
+        return self._score_windows(embedded_windows, config, device)

--- a/src/cordon/analysis/scorer.py
+++ b/src/cordon/analysis/scorer.py
@@ -7,6 +7,7 @@ import torch
 from tqdm import tqdm
 
 from cordon.core.config import AnalysisConfig
+from cordon.core.device import detect_device
 from cordon.core.types import ScoredWindow, TextWindow
 
 # Constants
@@ -23,55 +24,6 @@ class DensityAnomalyScorer:
     For large datasets, automatically switches to memory-mapped storage to
     reduce RAM usage.
     """
-
-    def _detect_device(self, config: AnalysisConfig) -> str:
-        """Detect the best available device for scoring.
-
-        Args:
-            config: Analysis configuration with optional device setting
-
-        Returns:
-            Device string: 'cuda', 'mps', or 'cpu'
-
-        Raises:
-            RuntimeError: If CUDA device is incompatible
-        """
-        if config.device is not None:
-            device = config.device
-            # validate CUDA compatibility if CUDA requested
-            if device == "cuda" and torch.cuda.is_available():
-                self._check_cuda_compatibility()
-            return device
-
-        # auto-detect device priority: cuda > mps > cpu
-        if torch.cuda.is_available():
-            self._check_cuda_compatibility()
-            return "cuda"
-        elif torch.backends.mps.is_available():
-            return "mps"
-        else:
-            return "cpu"
-
-    def _check_cuda_compatibility(self) -> None:
-        """Check if CUDA GPU is compatible with current PyTorch build.
-
-        Raises:
-            RuntimeError: If GPU compute capability is too old for PyTorch
-        """
-        if not torch.cuda.is_available():
-            return
-
-        # get compute capability
-        device_props = torch.cuda.get_device_properties(0)
-
-        # PyTorch 2.0+ requires compute capability >= 6.0 (Pascal or newer)
-        if device_props.major < 6:
-            gpu_name = device_props.name
-            compute_capability = f"{device_props.major}.{device_props.minor}"
-            raise RuntimeError(
-                f"GPU {gpu_name} (compute capability {compute_capability}) is not supported by "
-                f"PyTorch 2.0+. Requires compute capability >= 6.0 (Pascal architecture or newer)."
-            )
 
     def _calculate_n_neighbors(self, config: AnalysisConfig, n_samples: int) -> int:
         """Calculate the number of neighbors to use for k-NN.
@@ -346,7 +298,7 @@ class DensityAnomalyScorer:
             return [ScoredWindow(window=window, score=0.0, embedding=embedding)]
 
         # detect best available device
-        device = self._detect_device(config)
+        device = detect_device(config.device)
 
         # route to appropriate PyTorch implementation
         if device in ("cuda", "mps"):

--- a/src/cordon/cli.py
+++ b/src/cordon/cli.py
@@ -160,19 +160,15 @@ def analyze_file(
         print(f"Error: Not a file: {log_path}", file=sys.stderr)
         return
 
-    # count lines in file
-    with open(log_path) as log_file:
-        line_count = sum(1 for _ in log_file)
-
     print("=" * 80)
     print(f"Analyzing: {log_path}")
-    print(f"Total lines: {line_count:,}")
     print("=" * 80)
 
-    if detailed:
-        # run detailed analysis
-        result = analyzer.analyze_file_detailed(log_path)
+    result = analyzer.analyze_file_detailed(log_path)
 
+    print(f"Total lines: {result.total_lines:,}")
+
+    if detailed:
         print("\nAnalysis Statistics:")
         print(f"  Total windows created: {result.total_windows:,}")
         print(f"  Significant windows: {result.significant_windows:,}")
@@ -188,22 +184,11 @@ def analyze_file(
         print(f"\n{'Significant Blocks':^80}")
         print("=" * 80)
 
-        # write output to file or stdout
-        if output_path:
-            output_path.write_text(result.output)
-            print(f"Anomalous blocks written to: {output_path}")
-        else:
-            print(result.output)
+    if output_path:
+        output_path.write_text(result.output)
+        print(f"Anomalous blocks written to: {output_path}")
     else:
-        # run simple analysis
-        output = analyzer.analyze_file(log_path)
-
-        # write output to file or stdout
-        if output_path:
-            output_path.write_text(output)
-            print(f"Anomalous blocks written to: {output_path}")
-        else:
-            print(output)
+        print(result.output)
 
     print()
 

--- a/src/cordon/core/device.py
+++ b/src/cordon/core/device.py
@@ -1,0 +1,82 @@
+"""Shared device detection and CUDA compatibility utilities."""
+
+import logging
+from typing import Literal
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+
+def detect_device(requested: Literal["cuda", "mps", "cpu"] | None = None) -> str:
+    """Detect the best available device for PyTorch operations.
+
+    Args:
+        requested: Explicitly requested device, or None for auto-detection.
+
+    Returns:
+        Device string: 'cuda', 'mps', or 'cpu'.
+
+    Raises:
+        RuntimeError: If the requested device is unavailable or incompatible.
+    """
+    if requested is not None:
+        if requested == "cuda":
+            if not torch.cuda.is_available():
+                raise RuntimeError(
+                    "CUDA device requested but CUDA is not available. "
+                    "Use --device cpu or --device mps, or install a CUDA-compatible PyTorch build."
+                )
+            check_cuda_compatibility()
+        elif requested == "mps":
+            if not torch.backends.mps.is_available():
+                raise RuntimeError(
+                    "MPS device requested but MPS is not available. "
+                    "Use --device cpu or --device cuda."
+                )
+        return requested
+
+    # auto-detect: cuda > mps > cpu
+    if torch.cuda.is_available():
+        check_cuda_compatibility()
+        return "cuda"
+    elif torch.backends.mps.is_available():
+        return "mps"
+    else:
+        return "cpu"
+
+
+def check_cuda_compatibility() -> None:
+    """Check if CUDA GPU is compatible with current PyTorch build.
+
+    Raises:
+        RuntimeError: If GPU compute capability is too old for PyTorch 2.0+.
+    """
+
+    if not torch.cuda.is_available():
+        return
+
+    device_props = torch.cuda.get_device_properties(0)
+
+    if device_props.major < 6:
+        gpu_name = device_props.name
+        compute_capability = f"{device_props.major}.{device_props.minor}"
+        raise RuntimeError(
+            f"\n{'=' * 70}\n"
+            f"GPU COMPATIBILITY ERROR\n"
+            f"{'=' * 70}\n"
+            f"GPU: {gpu_name}\n"
+            f"Compute Capability: {compute_capability}\n"
+            f"\n"
+            f"PyTorch 2.0+ requires compute capability >= 6.0 (Pascal architecture or newer).\n"
+            f"Your GPU has compute capability {compute_capability}, which is not supported.\n"
+            f"\n"
+            f"Options:\n"
+            f"1. Use CPU mode: --device cpu\n"
+            f"2. Use a newer GPU (Pascal/GTX 10-series or later)\n"
+            f"3. Use llama.cpp backend for CPU inference:\n"
+            f"   cordon --backend llama-cpp --n-threads 8 <file>\n"
+            f"\n"
+            f"Supported GPUs: GTX 10-series, RTX series, Tesla P/V/A series, or newer\n"
+            f"{'=' * 70}\n"
+        )

--- a/src/cordon/core/types.py
+++ b/src/cordon/core/types.py
@@ -42,14 +42,12 @@ class ScoredWindow:
     """Window with its anomaly score.
 
     Attributes:
-        window: The text window
-        score: Anomaly score (higher = more anomalous)
-        embedding: Vector embedding for downstream use
+        window: The text window.
+        score: Anomaly score (higher = more anomalous).
     """
 
     window: TextWindow
     score: float
-    embedding: npt.NDArray[np.floating[Any]]
 
     def __post_init__(self) -> None:
         """Validate score is non-negative."""
@@ -90,15 +88,17 @@ class AnalysisResult:
     """Complete analysis result with metadata.
 
     Attributes:
-        output: Formatted output string with XML tags
-        total_windows: Total number of windows created
-        significant_windows: Number of windows above threshold
-        merged_blocks: Number of merged blocks in output
-        score_distribution: Statistical summary of scores
-        processing_time: Total processing time in seconds
+        output: Formatted output string with XML tags.
+        total_lines: Total number of lines in the input file.
+        total_windows: Total number of windows created.
+        significant_windows: Number of windows above threshold.
+        merged_blocks: Number of merged blocks in output.
+        score_distribution: Statistical summary of scores.
+        processing_time: Total processing time in seconds.
     """
 
     output: str
+    total_lines: int
     total_windows: int
     significant_windows: int
     merged_blocks: int

--- a/src/cordon/embedding/transformer.py
+++ b/src/cordon/embedding/transformer.py
@@ -9,6 +9,7 @@ from sentence_transformers import SentenceTransformer
 from tqdm import tqdm
 
 from cordon.core.config import AnalysisConfig
+from cordon.core.device import detect_device
 from cordon.core.types import TextWindow
 
 
@@ -27,74 +28,10 @@ class TransformerVectorizer:
             config: Analysis configuration specifying model and device
         """
         self.config = config
-        self.device = self._detect_device()
+        self.device = detect_device(self.config.device)
         self.model = SentenceTransformer(config.model_name)
         self.model.to(self.device)
         self._truncation_warned = False
-
-    def _detect_device(self) -> str:
-        """Detect the best available device for inference.
-
-        Returns:
-            Device string: 'cuda', 'mps', or 'cpu'
-
-        Raises:
-            RuntimeError: If CUDA device is incompatible
-        """
-        if self.config.device is not None:
-            device = self.config.device
-            # validate CUDA compatibility if CUDA requested
-            if device == "cuda" and torch.cuda.is_available():
-                self._check_cuda_compatibility()
-            return device
-
-        # auto-detect device priority: cuda > mps > cpu
-        if torch.cuda.is_available():
-            self._check_cuda_compatibility()
-            return "cuda"
-        elif torch.backends.mps.is_available():
-            return "mps"
-        else:
-            return "cpu"
-
-    def _check_cuda_compatibility(self) -> None:
-        """Check if CUDA GPU is compatible with current PyTorch build.
-
-        Raises:
-            RuntimeError: If GPU compute capability is too old for PyTorch
-        """
-        if not torch.cuda.is_available():
-            return
-
-        # get compute capability
-        device_props = torch.cuda.get_device_properties(0)
-        compute_capability = f"{device_props.major}.{device_props.minor}"
-        gpu_name = device_props.name
-
-        # PyTorch 2.0+ requires compute capability >= 6.0 (Pascal or newer)
-        if device_props.major < 6:
-            raise RuntimeError(
-                f"\n{'=' * 70}\n"
-                f"GPU COMPATIBILITY ERROR\n"
-                f"{'=' * 70}\n"
-                f"GPU: {gpu_name}\n"
-                f"Compute Capability: {compute_capability}\n"
-                f"\n"
-                f"PyTorch 2.0+ requires compute capability >= 6.0 (Pascal architecture or newer).\n"
-                f"Your GPU has compute capability {compute_capability}, which is not supported.\n"
-                f"\n"
-                f"Options:\n"
-                f"1. Use CPU mode: --device cpu\n"
-                f"   (Still benefits from PyTorch optimizations we added)\n"
-                f"\n"
-                f"2. Use a newer GPU (Pascal/GTX 10-series or later)\n"
-                f"\n"
-                f"3. Use llama.cpp backend for CPU inference:\n"
-                f"   cordon --backend llama-cpp --n-threads 8 <file>\n"
-                f"\n"
-                f"Supported GPUs: GTX 10-series, RTX series, Tesla P/V/A series, or newer\n"
-                f"{'=' * 70}\n"
-            )
 
     def embed_windows(
         self, windows: Iterable[TextWindow]

--- a/src/cordon/pipeline.py
+++ b/src/cordon/pipeline.py
@@ -29,6 +29,7 @@ class SemanticLogAnalyzer:
             config: Analysis configuration (uses defaults if None)
         """
         self.config = config if config is not None else AnalysisConfig()
+        self._vectorizer = create_vectorizer(self.config)
 
     def analyze_file(self, file_path: Path) -> str:
         """Analyze a log file and return formatted output.
@@ -55,20 +56,21 @@ class SemanticLogAnalyzer:
 
         # stage 1: ingestion
         reader = LogFileReader()
-        lines = reader.read_lines(file_path)
+        lines_list = list(reader.read_lines(file_path))
+        total_lines = len(lines_list)
 
         # stage 2: segmentation
         segmenter = SlidingWindowSegmenter()
-        windows = segmenter.segment(lines, self.config)
+        windows = segmenter.segment(iter(lines_list), self.config)
 
-        # stage 3: vectorization (using factory to select backend)
-        vectorizer = create_vectorizer(self.config)
-        embedded = list(vectorizer.embed_windows(windows))
+        # stage 3: vectorization
+        embedded = list(self._vectorizer.embed_windows(windows))
         total_windows = len(embedded)
 
         # stage 4: scoring
         scorer = DensityAnomalyScorer()
         scored = scorer.score_windows(embedded, self.config)
+        del embedded
 
         # stage 5: thresholding
         thresholder = Thresholder()
@@ -79,17 +81,20 @@ class SemanticLogAnalyzer:
         merger = IntervalMerger()
         merged = merger.merge_windows(significant)
         merged_blocks = len(merged)
+        del significant
 
         # stage 7: formatting
         formatter = OutputFormatter()
-        output = formatter.format_blocks(merged, file_path)
+        output = formatter.format_blocks(merged, lines_list)
 
         # calculate statistics
         processing_time = time.time() - start_time
         score_distribution = self._calculate_score_distribution(scored)
+        del scored
 
         return AnalysisResult(
             output=output,
+            total_lines=total_lines,
             total_windows=total_windows,
             significant_windows=significant_windows,
             merged_blocks=merged_blocks,

--- a/src/cordon/postprocess/formatter.py
+++ b/src/cordon/postprocess/formatter.py
@@ -1,5 +1,4 @@
 from collections.abc import Sequence
-from pathlib import Path
 from xml.sax.saxutils import escape
 
 from cordon.core.types import MergedBlock
@@ -13,36 +12,17 @@ class OutputFormatter:
     reference specific sections of the original file.
     """
 
-    def _format_block_xml(self, block: MergedBlock, content_lines: list[str]) -> str:
-        """Format a single block's content as an XML element.
-
-        Args:
-            block: The merged block with line range and score metadata.
-            content_lines: Raw lines from the original file for this block.
-
-        Returns:
-            XML string for the block with escaped, indented content.
-        """
-        tag = (
-            f'  <block lines="{block.start_line}-{block.end_line}" '
-            f'score="{block.max_score:.4f}">'
-        )
-        content = "".join(content_lines)
-        escaped_content = escape(content)
-        indented_content = "\n".join(
-            "    " + line if line else line for line in escaped_content.splitlines()
-        )
-        return f"{tag}\n{indented_content}\n  </block>"
-
-    def format_blocks(self, merged_blocks: Sequence[MergedBlock], original_file: Path) -> str:
+    def format_blocks(
+        self,
+        merged_blocks: Sequence[MergedBlock],
+        lines: Sequence[tuple[int, str]],
+    ) -> str:
         """Format merged blocks into XML-tagged output.
-
-        Uses single-pass streaming to efficiently handle large files by only
-        keeping anomalous blocks in memory.
 
         Args:
             merged_blocks: Sequence of merged blocks to format.
-            original_file: Path to original file (for extracting content).
+            lines: Sequence of (line_number, line_content) tuples from the
+                ingestion reader.
 
         Returns:
             Formatted string with XML tags and original content.
@@ -51,37 +31,30 @@ class OutputFormatter:
             return '<?xml version="1.0" encoding="UTF-8"?>\n<anomalies></anomalies>'
 
         sorted_blocks = sorted(merged_blocks, key=lambda b: b.start_line)
+        output_parts: list[str] = ['<?xml version="1.0" encoding="UTF-8"?>', "<anomalies>", ""]
 
-        output_parts = ['<?xml version="1.0" encoding="UTF-8"?>', "<anomalies>", ""]
-        block_idx = 0
-        current_line = 1
+        line_map = dict(lines)
 
-        with open(original_file, encoding="utf-8", errors="replace") as file_handle:
-            for line in file_handle:
-                if block_idx >= len(sorted_blocks):
-                    break
+        for block in sorted_blocks:
+            content_lines: list[str] = []
+            for line_num in range(block.start_line, block.end_line + 1):
+                line_content = line_map.get(line_num, "")
+                content_lines.append(line_content + "\n")
 
-                block = sorted_blocks[block_idx]
+            tag = (
+                f'  <block lines="{block.start_line}-{block.end_line}" '
+                f'score="{block.max_score:.4f}">'
+            )
+            content = "".join(content_lines)
+            escaped_content = escape(content)
 
-                if current_line == block.start_line:
-                    content_lines = [line]
+            indented_content = "\n".join(
+                "    " + content_line if content_line else content_line
+                for content_line in escaped_content.splitlines()
+            )
 
-                    while current_line < block.end_line:
-                        next_line = next(file_handle, None)
-                        if next_line is None:
-                            break
-                        content_lines.append(next_line)
-                        current_line += 1
-
-                    output_parts.append(self._format_block_xml(block, content_lines))
-                    output_parts.append("")
-
-                    block_idx += 1
-                    current_line = block.end_line + 1
-                    continue
-
-                current_line += 1
+            output_parts.append(f"{tag}\n{indented_content}\n  </block>")
+            output_parts.append("")
 
         output_parts.append("</anomalies>")
-
         return "\n".join(output_parts)

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -73,18 +73,15 @@ class TestDensityAnomalyScorer:
 
     def test_large_dataset_consistency(self) -> None:
         """Test that PyTorch handles large datasets consistently."""
-        # create enough windows to test scaling
         windows = [
             TextWindow(content=f"test{i}", start_line=i, end_line=i, window_id=i - 1)
             for i in range(1, 101)
         ]
-        # create diverse embeddings
         np.random.seed(42)
         embeddings = [np.random.randn(10).astype(np.float32) for _ in range(100)]
         embeddings = [e / np.linalg.norm(e) for e in embeddings]
         embedded = list(zip(windows, embeddings, strict=False))
 
-        # test with different batch sizes - should produce consistent results
         config_small_batch = AnalysisConfig(k_neighbors=5, scoring_batch_size=20, device="cpu")
         scorer = DensityAnomalyScorer()
         scored_small = scorer.score_windows(embedded, config_small_batch)
@@ -92,7 +89,6 @@ class TestDensityAnomalyScorer:
         config_large_batch = AnalysisConfig(k_neighbors=5, scoring_batch_size=50, device="cpu")
         scored_large = scorer.score_windows(embedded, config_large_batch)
 
-        # results should be identical regardless of batch size
         assert len(scored_small) == len(scored_large)
         for sw_small, sw_large in zip(scored_small, scored_large, strict=False):
             assert abs(sw_small.score - sw_large.score) < 1e-6
@@ -103,23 +99,19 @@ class TestDensityAnomalyScorer:
             TextWindow(content=f"test{i}", start_line=i, end_line=i, window_id=i - 1)
             for i in range(1, 11)
         ]
-        # create diverse embeddings
         np.random.seed(42)
         embeddings = [np.random.randn(10).astype(np.float32) for _ in range(10)]
         embeddings = [e / np.linalg.norm(e) for e in embeddings]
         embedded = list(zip(windows, embeddings, strict=False))
 
-        # test with CPU device explicitly
         config = AnalysisConfig(k_neighbors=3, device="cpu", scoring_batch_size=5)
         scorer = DensityAnomalyScorer()
         scored = scorer.score_windows(embedded, config)
 
-        # verify results
         assert len(scored) == 10
         for sw in scored:
             assert sw.score >= 0.0
             assert isinstance(sw.score, float)
-            assert len(sw.embedding) == 10
 
     def test_gpu_scoring_when_available(self) -> None:
         """Test that GPU scoring works when GPU is available."""
@@ -157,14 +149,12 @@ class TestDensityAnomalyScorer:
         embeddings = [e / np.linalg.norm(e) for e in embeddings]
         embedded = list(zip(windows, embeddings, strict=False))
 
-        # test with different batch sizes (should all work without error)
         for batch_size in [5, 10, 25, 100]:
             config = AnalysisConfig(k_neighbors=3, device="cpu", scoring_batch_size=batch_size)
             scorer = DensityAnomalyScorer()
             scored = scorer.score_windows(embedded, config)
             assert len(scored) == 25
 
-        # test auto-detection (None)
         config_auto = AnalysisConfig(k_neighbors=3, device="cpu", scoring_batch_size=None)
         scorer_auto = DensityAnomalyScorer()
         scored_auto = scorer_auto.score_windows(embedded, config_auto)
@@ -245,19 +235,14 @@ class TestThresholder:
             TextWindow(content=f"test{i}", start_line=i, end_line=i, window_id=i - 1)
             for i in range(1, 101)
         ]
-        embeddings = [np.array([float(i)]) for i in range(100)]
-        scored = [
-            ScoredWindow(window=w, score=float(i), embedding=e)
-            for i, (w, e) in enumerate(zip(windows, embeddings, strict=False))
-        ]
+        scored = [ScoredWindow(window=w, score=float(i)) for i, w in enumerate(windows)]
         config = AnalysisConfig(anomaly_percentile=0.1)
 
         thresholder = Thresholder()
         significant = thresholder.select_significant(scored, config)
 
-        # should get approximately 10 windows
         assert len(significant) >= 10
-        assert len(significant) <= 11  # allow for ties at threshold
+        assert len(significant) <= 11
 
     def test_select_all_windows(self) -> None:
         """Test selecting all windows with ratio=1.0."""
@@ -265,11 +250,7 @@ class TestThresholder:
             TextWindow(content=f"test{i}", start_line=i, end_line=i, window_id=i - 1)
             for i in range(1, 11)
         ]
-        embeddings = [np.array([float(i)]) for i in range(10)]
-        scored = [
-            ScoredWindow(window=w, score=float(i), embedding=e)
-            for i, (w, e) in enumerate(zip(windows, embeddings, strict=False))
-        ]
+        scored = [ScoredWindow(window=w, score=float(i)) for i, w in enumerate(windows)]
         config = AnalysisConfig(anomaly_percentile=1.0)
 
         thresholder = Thresholder()
@@ -283,11 +264,7 @@ class TestThresholder:
             TextWindow(content=f"test{i}", start_line=i, end_line=i, window_id=i - 1)
             for i in range(1, 11)
         ]
-        embeddings = [np.array([float(i)]) for i in range(10)]
-        scored = [
-            ScoredWindow(window=w, score=float(i), embedding=e)
-            for i, (w, e) in enumerate(zip(windows, embeddings, strict=False))
-        ]
+        scored = [ScoredWindow(window=w, score=float(i)) for i, w in enumerate(windows)]
         config = AnalysisConfig(anomaly_percentile=0.0)
 
         thresholder = Thresholder()
@@ -311,19 +288,13 @@ class TestThresholder:
             TextWindow(content=f"test{i}", start_line=i, end_line=i, window_id=i - 1)
             for i in range(1, 11)
         ]
-        embeddings = [np.array([float(i)]) for i in range(10)]
-        # create scores in random order
         scores = [5.0, 2.0, 8.0, 1.0, 9.0, 3.0, 7.0, 4.0, 6.0, 0.0]
-        scored = [
-            ScoredWindow(window=w, score=s, embedding=e)
-            for w, s, e in zip(windows, scores, embeddings, strict=False)
-        ]
+        scored = [ScoredWindow(window=w, score=s) for w, s in zip(windows, scores, strict=False)]
         config = AnalysisConfig(anomaly_percentile=0.5)
 
         thresholder = Thresholder()
         significant = thresholder.select_significant(scored, config)
 
-        # verify sorted descending
         for i in range(len(significant) - 1):
             assert significant[i].score >= significant[i + 1].score
 
@@ -333,28 +304,18 @@ class TestThresholder:
             TextWindow(content=f"test{i}", start_line=i, end_line=i, window_id=i - 1)
             for i in range(1, 101)
         ]
-        embeddings = [np.array([float(i)]) for i in range(100)]
-        # scores from 0.0 to 99.0
-        scored = [
-            ScoredWindow(window=w, score=float(i), embedding=e)
-            for i, (w, e) in enumerate(zip(windows, embeddings, strict=False))
-        ]
-        # exclude top 5% (scores >= 95th percentile = 94.05)
-        # keep up to 15% (scores >= 85th percentile = 84.15)
-        # result: scores in range [84.15, 94.05)
+        scored = [ScoredWindow(window=w, score=float(i)) for i, w in enumerate(windows)]
         config = AnalysisConfig(anomaly_range_min=0.05, anomaly_range_max=0.15)
 
         thresholder = Thresholder()
         significant = thresholder.select_significant(scored, config)
 
-        # should get approximately 10 windows (between 85th and 95th percentile)
         assert len(significant) >= 9
-        assert len(significant) <= 11  # allow for boundary effects
+        assert len(significant) <= 11
 
-        # verify all selected scores are in expected range
         for sw in significant:
-            assert sw.score < 95.0  # below 95th percentile
-            assert sw.score >= 84.0  # at or above 85th percentile
+            assert sw.score < 95.0
+            assert sw.score >= 84.0
 
     def test_range_mode_sorted_descending(self) -> None:
         """Test that range mode results are sorted by score (descending)."""
@@ -362,20 +323,16 @@ class TestThresholder:
             TextWindow(content=f"test{i}", start_line=i, end_line=i, window_id=i - 1)
             for i in range(1, 51)
         ]
-        embeddings = [np.array([float(i)]) for i in range(50)]
-        # random scores
         scores = list(range(50))
         np.random.shuffle(scores)
         scored = [
-            ScoredWindow(window=w, score=float(s), embedding=e)
-            for w, s, e in zip(windows, scores, embeddings, strict=False)
+            ScoredWindow(window=w, score=float(s)) for w, s in zip(windows, scores, strict=False)
         ]
         config = AnalysisConfig(anomaly_range_min=0.1, anomaly_range_max=0.3)
 
         thresholder = Thresholder()
         significant = thresholder.select_significant(scored, config)
 
-        # verify sorted descending
         for i in range(len(significant) - 1):
             assert significant[i].score >= significant[i + 1].score
 
@@ -385,19 +342,12 @@ class TestThresholder:
             TextWindow(content=f"test{i}", start_line=i, end_line=i, window_id=i - 1)
             for i in range(1, 11)
         ]
-        embeddings = [np.array([float(i)]) for i in range(10)]
-        # all scores are 5.0
-        scored = [
-            ScoredWindow(window=w, score=5.0, embedding=e)
-            for w, e in zip(windows, embeddings, strict=False)
-        ]
-        # with identical scores, percentile range will be very narrow
+        scored = [ScoredWindow(window=w, score=5.0) for w in windows]
         config = AnalysisConfig(anomaly_range_min=0.01, anomaly_range_max=0.05)
 
         thresholder = Thresholder()
         significant = thresholder.select_significant(scored, config)
 
-        # with identical scores, might get some or none depending on boundaries
         assert len(significant) >= 0
 
     def test_range_mode_vs_percentile_mode(self) -> None:
@@ -406,37 +356,25 @@ class TestThresholder:
             TextWindow(content=f"test{i}", start_line=i, end_line=i, window_id=i - 1)
             for i in range(1, 101)
         ]
-        embeddings = [np.array([float(i)]) for i in range(100)]
-        scored = [
-            ScoredWindow(window=w, score=float(i), embedding=e)
-            for i, (w, e) in enumerate(zip(windows, embeddings, strict=False))
-        ]
+        scored = [ScoredWindow(window=w, score=float(i)) for i, w in enumerate(windows)]
 
-        # percentile mode: top 10% (scores >= 90th percentile)
         config_percentile = AnalysisConfig(anomaly_percentile=0.1)
         thresholder = Thresholder()
         sig_percentile = thresholder.select_significant(scored, config_percentile)
 
-        # range mode: exclude top 5%, keep next 10% (scores 85th-95th percentile)
         config_range = AnalysisConfig(anomaly_range_min=0.05, anomaly_range_max=0.15)
         sig_range = thresholder.select_significant(scored, config_range)
 
-        # Both return 10 windows, but different score ranges
         assert len(sig_percentile) == 10
         assert len(sig_range) == 10
 
-        # percentile mode should include the highest scores (90-99)
-        # range mode should exclude the top 5% and return 85-94
         assert max(sw.score for sw in sig_percentile) > max(sw.score for sw in sig_range)
         assert min(sw.score for sw in sig_percentile) > min(sw.score for sw in sig_range)
 
-        # Verify specific ranges
         pct_scores = [sw.score for sw in sig_percentile]
         range_scores = [sw.score for sw in sig_range]
 
-        # Percentile mode: should have scores >= 90
         assert all(s >= 90.0 for s in pct_scores)
-        # Range mode: should have scores in [85, 95)
         assert all(85.0 <= s < 95.0 for s in range_scores)
 
     def test_range_mode_boundary_inclusive_exclusive(self) -> None:
@@ -445,22 +383,12 @@ class TestThresholder:
             TextWindow(content=f"test{i}", start_line=i, end_line=i, window_id=i - 1)
             for i in range(1, 101)
         ]
-        embeddings = [np.array([float(i)]) for i in range(100)]
-        # scores from 0 to 99
-        scored = [
-            ScoredWindow(window=w, score=float(i), embedding=e)
-            for i, (w, e) in enumerate(zip(windows, embeddings, strict=False))
-        ]
-        # exclude top 10% (score < 90th percentile = 89.1)
-        # keep up to 20% (score >= 80th percentile = 79.2)
+        scored = [ScoredWindow(window=w, score=float(i)) for i, w in enumerate(windows)]
         config = AnalysisConfig(anomaly_range_min=0.1, anomaly_range_max=0.2)
 
         thresholder = Thresholder()
         significant = thresholder.select_significant(scored, config)
 
-        # verify boundaries
         for sw in significant:
-            # should be less than upper threshold (exclusive)
             assert sw.score < 90.0
-            # should be at or above lower threshold (inclusive)
             assert sw.score >= 79.0

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -99,25 +99,6 @@ class TestDensityAnomalyScorer:
         for sw_small, sw_large in zip(scored_small, scored_large, strict=False):
             assert abs(sw_small.score - sw_large.score) < 1e-6
 
-    def test_device_detection(self) -> None:
-        """Test that device detection respects config and auto-detects correctly."""
-        scorer = DensityAnomalyScorer()
-
-        # test explicit device settings
-        config_cpu = AnalysisConfig(device="cpu")
-        assert scorer._detect_device(config_cpu) == "cpu"
-
-        config_cuda = AnalysisConfig(device="cuda")
-        assert scorer._detect_device(config_cuda) == "cuda"
-
-        config_mps = AnalysisConfig(device="mps")
-        assert scorer._detect_device(config_mps) == "mps"
-
-        # test auto-detection (should return one of the supported devices)
-        config_auto = AnalysisConfig()
-        device = scorer._detect_device(config_auto)
-        assert device in ("cuda", "mps", "cpu")
-
     def test_pytorch_scoring_cpu(self) -> None:
         """Test that PyTorch scoring works correctly on CPU."""
         windows = [

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -1,6 +1,7 @@
 """Tests for analysis module."""
 
 import numpy as np
+import pytest
 import torch
 
 from cordon.analysis.scorer import DensityAnomalyScorer
@@ -39,9 +40,7 @@ class TestDensityAnomalyScorer:
             TextWindow(content="test", start_line=i, end_line=i, window_id=i - 1)
             for i in range(1, 6)
         ]
-        # all embeddings very similar
         embeddings = [np.array([0.1, 0.2, 0.3]) + np.random.randn(3) * 0.01 for _ in range(5)]
-        # normalize
         embeddings = [e / np.linalg.norm(e) for e in embeddings]
         embedded = list(zip(windows, embeddings, strict=False))
         config = AnalysisConfig(k_neighbors=3)
@@ -49,8 +48,8 @@ class TestDensityAnomalyScorer:
         scorer = DensityAnomalyScorer()
         scored = scorer.score_windows(embedded, config)
 
-        # all scores should be relatively small
         for sw in scored:
+            assert sw.score >= 0.0
             assert sw.score < 0.2
 
     def test_score_diverse_windows(self) -> None:
@@ -59,10 +58,8 @@ class TestDensityAnomalyScorer:
             TextWindow(content=f"test{i}", start_line=i, end_line=i, window_id=i - 1)
             for i in range(1, 7)
         ]
-        # create 5 similar embeddings and 1 outlier
         embeddings = [np.array([0.1, 0.2, 0.3]) for _ in range(5)]
-        embeddings.append(np.array([0.9, 0.1, 0.1]))  # outlier
-        # normalize
+        embeddings.append(np.array([0.9, 0.1, 0.1]))
         embeddings = [e / np.linalg.norm(e) for e in embeddings]
         embedded = list(zip(windows, embeddings, strict=False))
         config = AnalysisConfig(k_neighbors=3)
@@ -70,7 +67,8 @@ class TestDensityAnomalyScorer:
         scorer = DensityAnomalyScorer()
         scored = scorer.score_windows(embedded, config)
 
-        # outlier (last window) should have highest score
+        for sw in scored:
+            assert sw.score >= 0.0
         assert scored[-1].score > scored[0].score
 
     def test_large_dataset_consistency(self) -> None:
@@ -133,20 +131,17 @@ class TestDensityAnomalyScorer:
         embeddings = [e / np.linalg.norm(e) for e in embeddings]
         embedded = list(zip(windows, embeddings, strict=False))
 
-        # only run if GPU is available
         if torch.cuda.is_available():
             device = "cuda"
         elif torch.backends.mps.is_available():
             device = "mps"
         else:
-            # skip test if no GPU available
-            return
+            pytest.skip("No GPU available")
 
         config = AnalysisConfig(k_neighbors=3, device=device, scoring_batch_size=5)
         scorer = DensityAnomalyScorer()
-        scored = scorer._score_windows_gpu(embedded, config, device)
+        scored = scorer._score_windows(embedded, config, device)
 
-        # verify results
         assert len(scored) == 10
         for sw in scored:
             assert sw.score >= 0.0
@@ -177,7 +172,6 @@ class TestDensityAnomalyScorer:
 
     def test_pytorch_gpu_availability(self) -> None:
         """Test that PyTorch GPU implementation runs if GPU is available."""
-        # this test will use GPU if available, otherwise skip to CPU
         windows = [
             TextWindow(content=f"test{i}", start_line=i, end_line=i, window_id=i - 1)
             for i in range(1, 11)
@@ -186,15 +180,60 @@ class TestDensityAnomalyScorer:
         embeddings = [e / np.linalg.norm(e) for e in embeddings]
         embedded = list(zip(windows, embeddings, strict=False))
 
-        # test with auto-detected device
         config = AnalysisConfig(k_neighbors=3, scoring_batch_size=5)
         scorer = DensityAnomalyScorer()
         scored = scorer.score_windows(embedded, config)
 
-        # should work regardless of GPU availability
         assert len(scored) == 10
         for sw in scored:
             assert sw.score >= 0.0
+
+    def test_score_two_windows(self) -> None:
+        """Test scoring with only 2 windows to verify chunk_size clamping."""
+        windows = [
+            TextWindow(content="a", start_line=1, end_line=1, window_id=0),
+            TextWindow(content="b", start_line=2, end_line=2, window_id=1),
+        ]
+        embeddings = [
+            np.array([1.0, 0.0, 0.0], dtype=np.float32),
+            np.array([0.0, 1.0, 0.0], dtype=np.float32),
+        ]
+        embedded = list(zip(windows, embeddings, strict=False))
+        config = AnalysisConfig(k_neighbors=1, device="cpu", scoring_batch_size=5)
+
+        scorer = DensityAnomalyScorer()
+        scored = scorer.score_windows(embedded, config)
+
+        assert len(scored) == 2
+        for sw in scored:
+            assert sw.score >= 0.0
+            assert isinstance(sw.score, float)
+
+    def test_score_unnormalized_embeddings(self) -> None:
+        """Test that unnormalized embeddings still produce valid scores.
+
+        The scorer normalizes internally, so raw embeddings with arbitrary
+        norms should still yield non-negative, finite scores.
+        """
+        windows = [
+            TextWindow(content=f"test{i}", start_line=i, end_line=i, window_id=i - 1)
+            for i in range(1, 11)
+        ]
+        np.random.seed(99)
+        embeddings = [np.random.randn(8).astype(np.float32) * 5.0 for _ in range(10)]
+        norms = [np.linalg.norm(e) for e in embeddings]
+        assert all(abs(n - 1.0) > 0.1 for n in norms), "Embeddings should not be unit norm"
+
+        embedded = list(zip(windows, embeddings, strict=False))
+        config = AnalysisConfig(k_neighbors=3, device="cpu", scoring_batch_size=5)
+
+        scorer = DensityAnomalyScorer()
+        scored = scorer.score_windows(embedded, config)
+
+        assert len(scored) == 10
+        for sw in scored:
+            assert sw.score >= 0.0
+            assert np.isfinite(sw.score)
 
 
 class TestThresholder:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,6 +1,5 @@
 import dataclasses
 
-import numpy as np
 import pytest
 
 from cordon.core.config import AnalysisConfig
@@ -42,11 +41,9 @@ class TestScoredWindow:
     def test_valid_scored_window(self) -> None:
         """Test creating a valid scored window."""
         window = TextWindow(content="test", start_line=1, end_line=5, window_id=0)
-        embedding = np.array([0.1, 0.2, 0.3])
-        scored = ScoredWindow(window=window, score=0.5, embedding=embedding)
+        scored = ScoredWindow(window=window, score=0.5)
         assert scored.window == window
         assert scored.score == 0.5
-        np.testing.assert_array_equal(scored.embedding, embedding)
 
 
 class TestMergedBlock:

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1,0 +1,80 @@
+"""Tests for shared device detection utility."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cordon.core.device import check_cuda_compatibility, detect_device
+
+
+class TestDetectDevice:
+    """Tests for detect_device function."""
+
+    @patch("cordon.core.device.torch")
+    def test_auto_detect_cpu_fallback(self, mock_torch: MagicMock) -> None:
+        """Test auto-detection falls back to CPU when no GPU available."""
+        mock_torch.cuda.is_available.return_value = False
+        mock_torch.backends.mps.is_available.return_value = False
+        assert detect_device(None) == "cpu"
+
+    @patch("cordon.core.device.torch")
+    def test_auto_detect_cuda(self, mock_torch: MagicMock) -> None:
+        """Test auto-detection selects CUDA when available."""
+        mock_torch.cuda.is_available.return_value = True
+        mock_torch.cuda.get_device_properties.return_value = MagicMock(
+            major=8, minor=0, name="RTX 3090"
+        )
+        assert detect_device(None) == "cuda"
+
+    @patch("cordon.core.device.torch")
+    def test_auto_detect_mps(self, mock_torch: MagicMock) -> None:
+        """Test auto-detection selects MPS when CUDA unavailable."""
+        mock_torch.cuda.is_available.return_value = False
+        mock_torch.backends.mps.is_available.return_value = True
+        assert detect_device(None) == "mps"
+
+    @patch("cordon.core.device.torch")
+    def test_explicit_cuda_unavailable_raises(self, mock_torch: MagicMock) -> None:
+        """Test that explicitly requesting CUDA when unavailable raises RuntimeError."""
+        mock_torch.cuda.is_available.return_value = False
+        with pytest.raises(RuntimeError, match="CUDA device requested but CUDA is not available"):
+            detect_device("cuda")
+
+    @patch("cordon.core.device.torch")
+    def test_explicit_cpu(self, mock_torch: MagicMock) -> None:
+        """Test that explicitly requesting CPU works."""
+        assert detect_device("cpu") == "cpu"
+
+    @patch("cordon.core.device.torch")
+    def test_explicit_mps(self, mock_torch: MagicMock) -> None:
+        """Test that explicitly requesting MPS works."""
+        assert detect_device("mps") == "mps"
+
+
+class TestCheckCudaCompatibility:
+    """Tests for check_cuda_compatibility function."""
+
+    @patch("cordon.core.device.torch")
+    def test_compatible_gpu(self, mock_torch: MagicMock) -> None:
+        """Test that a compatible GPU passes without error."""
+        mock_torch.cuda.is_available.return_value = True
+        mock_torch.cuda.get_device_properties.return_value = MagicMock(
+            major=7, minor=5, name="RTX 2080"
+        )
+        check_cuda_compatibility()
+
+    @patch("cordon.core.device.torch")
+    def test_incompatible_gpu(self, mock_torch: MagicMock) -> None:
+        """Test that an incompatible GPU raises RuntimeError."""
+        mock_torch.cuda.is_available.return_value = True
+        mock_torch.cuda.get_device_properties.return_value = MagicMock(
+            major=5, minor=0, name="GTX 960"
+        )
+        with pytest.raises(RuntimeError, match="GPU COMPATIBILITY ERROR"):
+            check_cuda_compatibility()
+
+    @patch("cordon.core.device.torch")
+    def test_no_cuda_available(self, mock_torch: MagicMock) -> None:
+        """Test that check passes when CUDA is not available."""
+        mock_torch.cuda.is_available.return_value = False
+        check_cuda_compatibility()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -33,6 +33,7 @@ class TestIntegration:
             result = analyzer.analyze_file_detailed(temp_path)
 
             # verify result structure
+            assert result.total_lines == 43
             assert result.total_windows > 0
             assert result.significant_windows > 0
             assert result.merged_blocks >= 0
@@ -53,6 +54,7 @@ class TestIntegration:
             analyzer = SemanticLogAnalyzer(config)
             result = analyzer.analyze_file_detailed(temp_path)
 
+            assert result.total_lines == 0
             assert result.total_windows == 0
             assert result.significant_windows == 0
             assert result.merged_blocks == 0
@@ -73,6 +75,7 @@ class TestIntegration:
             analyzer = SemanticLogAnalyzer(config)
             result = analyzer.analyze_file_detailed(temp_path)
 
+            assert result.total_lines == 1
             assert result.total_windows == 1
             # single window gets score 0.0, might not be selected
             assert result.processing_time > 0

--- a/tests/test_postprocess.py
+++ b/tests/test_postprocess.py
@@ -1,9 +1,4 @@
-from pathlib import Path
-from tempfile import NamedTemporaryFile
-
-import numpy as np
-
-from cordon.core.types import ScoredWindow, TextWindow
+from cordon.core.types import MergedBlock, ScoredWindow, TextWindow
 from cordon.postprocess.formatter import OutputFormatter
 from cordon.postprocess.merger import IntervalMerger
 
@@ -13,14 +8,15 @@ class TestIntervalMerger:
 
     def test_merge_no_overlap(self) -> None:
         """Test merging windows with no overlap."""
-        windows = [
-            TextWindow(content="w1", start_line=1, end_line=3, window_id=0),
-            TextWindow(content="w2", start_line=10, end_line=12, window_id=1),
-        ]
-        embeddings = [np.array([0.1]), np.array([0.2])]
         scored = [
-            ScoredWindow(window=w, score=0.5, embedding=e)
-            for w, e in zip(windows, embeddings, strict=False)
+            ScoredWindow(
+                window=TextWindow(content="w1", start_line=1, end_line=3, window_id=0),
+                score=0.5,
+            ),
+            ScoredWindow(
+                window=TextWindow(content="w2", start_line=10, end_line=12, window_id=1),
+                score=0.5,
+            ),
         ]
 
         merger = IntervalMerger()
@@ -34,15 +30,19 @@ class TestIntervalMerger:
 
     def test_merge_overlapping_windows(self) -> None:
         """Test merging overlapping windows."""
-        windows = [
-            TextWindow(content="w1", start_line=1, end_line=5, window_id=0),
-            TextWindow(content="w2", start_line=3, end_line=7, window_id=1),
-            TextWindow(content="w3", start_line=6, end_line=10, window_id=2),
-        ]
-        embeddings = [np.array([0.1]), np.array([0.2]), np.array([0.3])]
         scored = [
-            ScoredWindow(window=w, score=0.5, embedding=e)
-            for w, e in zip(windows, embeddings, strict=False)
+            ScoredWindow(
+                window=TextWindow(content="w1", start_line=1, end_line=5, window_id=0),
+                score=0.5,
+            ),
+            ScoredWindow(
+                window=TextWindow(content="w2", start_line=3, end_line=7, window_id=1),
+                score=0.5,
+            ),
+            ScoredWindow(
+                window=TextWindow(content="w3", start_line=6, end_line=10, window_id=2),
+                score=0.5,
+            ),
         ]
 
         merger = IntervalMerger()
@@ -55,14 +55,15 @@ class TestIntervalMerger:
 
     def test_merge_adjacent_windows(self) -> None:
         """Test merging adjacent windows (lines N and N+1)."""
-        windows = [
-            TextWindow(content="w1", start_line=1, end_line=5, window_id=0),
-            TextWindow(content="w2", start_line=6, end_line=10, window_id=1),
-        ]
-        embeddings = [np.array([0.1]), np.array([0.2])]
         scored = [
-            ScoredWindow(window=w, score=0.5, embedding=e)
-            for w, e in zip(windows, embeddings, strict=False)
+            ScoredWindow(
+                window=TextWindow(content="w1", start_line=1, end_line=5, window_id=0),
+                score=0.5,
+            ),
+            ScoredWindow(
+                window=TextWindow(content="w2", start_line=6, end_line=10, window_id=1),
+                score=0.5,
+            ),
         ]
 
         merger = IntervalMerger()
@@ -75,14 +76,15 @@ class TestIntervalMerger:
 
     def test_merge_preserves_max_score(self) -> None:
         """Test that merging preserves the maximum score."""
-        windows = [
-            TextWindow(content="w1", start_line=1, end_line=5, window_id=0),
-            TextWindow(content="w2", start_line=3, end_line=7, window_id=1),
-        ]
-        embeddings = [np.array([0.1]), np.array([0.2])]
         scored = [
-            ScoredWindow(window=windows[0], score=0.8, embedding=embeddings[0]),
-            ScoredWindow(window=windows[1], score=0.5, embedding=embeddings[1]),
+            ScoredWindow(
+                window=TextWindow(content="w1", start_line=1, end_line=5, window_id=0),
+                score=0.8,
+            ),
+            ScoredWindow(
+                window=TextWindow(content="w2", start_line=3, end_line=7, window_id=1),
+                score=0.5,
+            ),
         ]
 
         merger = IntervalMerger()
@@ -102,11 +104,11 @@ class TestIntervalMerger:
 
     def test_merge_single_window(self) -> None:
         """Test merging with a single window."""
-        windows = [TextWindow(content="w1", start_line=1, end_line=5, window_id=0)]
-        embeddings = [np.array([0.1])]
         scored = [
-            ScoredWindow(window=w, score=0.5, embedding=e)
-            for w, e in zip(windows, embeddings, strict=False)
+            ScoredWindow(
+                window=TextWindow(content="w1", start_line=1, end_line=5, window_id=0),
+                score=0.5,
+            ),
         ]
 
         merger = IntervalMerger()
@@ -122,182 +124,117 @@ class TestOutputFormatter:
 
     def test_format_single_block(self) -> None:
         """Test formatting a single block."""
-        with NamedTemporaryFile(mode="w", delete=False, suffix=".log") as f:
-            f.write("line 1\n")
-            f.write("line 2\n")
-            f.write("line 3\n")
-            temp_path = Path(f.name)
+        lines = [(1, "line 1"), (2, "line 2"), (3, "line 3")]
+        blocks = [MergedBlock(start_line=1, end_line=2, original_windows=(0,), max_score=0.8)]
 
-        try:
-            from cordon.core.types import MergedBlock
+        formatter = OutputFormatter()
+        output = formatter.format_blocks(blocks, lines)
 
-            blocks = [MergedBlock(start_line=1, end_line=2, original_windows=(0,), max_score=0.8)]
-
-            formatter = OutputFormatter()
-            output = formatter.format_blocks(blocks, temp_path)
-
-            assert '<?xml version="1.0" encoding="UTF-8"?>' in output
-            assert "<anomalies>" in output
-            assert "</anomalies>" in output
-            assert '<block lines="1-2" score="0.8000">' in output
-            assert "line 1\n" in output
-            assert "line 2\n" in output
-            assert "</block>" in output
-        finally:
-            temp_path.unlink()
+        assert '<?xml version="1.0" encoding="UTF-8"?>' in output
+        assert "<anomalies>" in output
+        assert "</anomalies>" in output
+        assert '<block lines="1-2" score="0.8000">' in output
+        assert "line 1" in output
+        assert "line 2" in output
+        assert "</block>" in output
 
     def test_format_multiple_blocks(self) -> None:
         """Test formatting multiple blocks."""
-        with NamedTemporaryFile(mode="w", delete=False, suffix=".log") as f:
-            for i in range(1, 11):
-                f.write(f"line {i}\n")
-            temp_path = Path(f.name)
+        lines = [(i, f"line {i}") for i in range(1, 11)]
+        blocks = [
+            MergedBlock(start_line=1, end_line=2, original_windows=(0,), max_score=0.8),
+            MergedBlock(start_line=5, end_line=7, original_windows=(1,), max_score=0.9),
+        ]
 
-        try:
-            from cordon.core.types import MergedBlock
+        formatter = OutputFormatter()
+        output = formatter.format_blocks(blocks, lines)
 
-            blocks = [
-                MergedBlock(start_line=1, end_line=2, original_windows=(0,), max_score=0.8),
-                MergedBlock(start_line=5, end_line=7, original_windows=(1,), max_score=0.9),
-            ]
-
-            formatter = OutputFormatter()
-            output = formatter.format_blocks(blocks, temp_path)
-
-            assert '<?xml version="1.0" encoding="UTF-8"?>' in output
-            assert "<anomalies>" in output
-            assert "</anomalies>" in output
-            assert '<block lines="1-2" score="0.8000">' in output
-            assert '<block lines="5-7" score="0.9000">' in output
-            assert output.count("</block>") == 2
-        finally:
-            temp_path.unlink()
+        assert '<?xml version="1.0" encoding="UTF-8"?>' in output
+        assert "<anomalies>" in output
+        assert "</anomalies>" in output
+        assert '<block lines="1-2" score="0.8000">' in output
+        assert '<block lines="5-7" score="0.9000">' in output
+        assert output.count("</block>") == 2
 
     def test_format_empty_blocks(self) -> None:
         """Test formatting with no blocks."""
-        with NamedTemporaryFile(mode="w", delete=False, suffix=".log") as f:
-            f.write("line 1\n")
-            temp_path = Path(f.name)
+        lines = [(1, "line 1")]
+        blocks: list[MergedBlock] = []
 
-        try:
-            from cordon.core.types import MergedBlock
+        formatter = OutputFormatter()
+        output = formatter.format_blocks(blocks, lines)
 
-            blocks: list[MergedBlock] = []
-
-            formatter = OutputFormatter()
-            output = formatter.format_blocks(blocks, temp_path)
-
-            assert output == '<?xml version="1.0" encoding="UTF-8"?>\n<anomalies></anomalies>'
-        finally:
-            temp_path.unlink()
+        assert output == '<?xml version="1.0" encoding="UTF-8"?>\n<anomalies></anomalies>'
 
     def test_format_escapes_xml_special_chars(self) -> None:
         """Test that XML special characters are properly escaped."""
-        with NamedTemporaryFile(mode="w", delete=False, suffix=".log") as f:
-            f.write("command: test |& tee file.txt\n")
-            f.write("error: x < y && z > 10\n")
-            f.write("message: \"quoted\" & 'single'\n")
-            temp_path = Path(f.name)
+        lines = [
+            (1, "command: test |& tee file.txt"),
+            (2, "error: x < y && z > 10"),
+            (3, "message: \"quoted\" & 'single'"),
+        ]
+        blocks = [MergedBlock(start_line=1, end_line=3, original_windows=(0,), max_score=0.8)]
 
-        try:
-            from cordon.core.types import MergedBlock
+        formatter = OutputFormatter()
+        output = formatter.format_blocks(blocks, lines)
 
-            blocks = [MergedBlock(start_line=1, end_line=3, original_windows=(0,), max_score=0.8)]
-
-            formatter = OutputFormatter()
-            output = formatter.format_blocks(blocks, temp_path)
-
-            # Verify XML structure
-            assert '<?xml version="1.0" encoding="UTF-8"?>' in output
-            assert "<anomalies>" in output
-            assert "</anomalies>" in output
-            # Verify XML special characters are escaped (& < > must be escaped in text content)
-            assert "&amp;" in output
-            assert "&lt;" in output
-            assert "&gt;" in output
-            # Verify the content is properly escaped
-            assert "command: test |&amp; tee file.txt" in output
-            assert "error: x &lt; y &amp;&amp; z &gt; 10" in output
-            # Verify raw special characters are not present where they should be escaped
-            assert "|& tee" not in output  # & should be escaped
-            assert "x < y" not in output  # < should be escaped
-            assert "z > 10" not in output  # > should be escaped
-        finally:
-            temp_path.unlink()
+        assert '<?xml version="1.0" encoding="UTF-8"?>' in output
+        assert "<anomalies>" in output
+        assert "</anomalies>" in output
+        assert "&amp;" in output
+        assert "&lt;" in output
+        assert "&gt;" in output
+        assert "command: test |&amp; tee file.txt" in output
+        assert "error: x &lt; y &amp;&amp; z &gt; 10" in output
+        assert "|& tee" not in output
+        assert "x < y" not in output
+        assert "z > 10" not in output
 
     def test_format_multi_block_content_correctness(self) -> None:
         """Test that multi-block formatting extracts correct content for each block."""
-        with NamedTemporaryFile(mode="w", delete=False, suffix=".log") as f:
-            for i in range(1, 11):
-                f.write(f"line {i}\n")
-            temp_path = Path(f.name)
+        lines = [(i, f"line {i}") for i in range(1, 11)]
+        blocks = [
+            MergedBlock(start_line=2, end_line=3, original_windows=(0,), max_score=0.7),
+            MergedBlock(start_line=7, end_line=8, original_windows=(1,), max_score=0.9),
+        ]
 
-        try:
-            from cordon.core.types import MergedBlock
+        formatter = OutputFormatter()
+        output = formatter.format_blocks(blocks, lines)
 
-            blocks = [
-                MergedBlock(start_line=2, end_line=3, original_windows=(0,), max_score=0.7),
-                MergedBlock(start_line=7, end_line=8, original_windows=(1,), max_score=0.9),
-            ]
-
-            formatter = OutputFormatter()
-            output = formatter.format_blocks(blocks, temp_path)
-
-            assert "line 7" in output
-            assert "line 8" in output
-            assert '<block lines="7-8" score="0.9000">' in output
-            assert "line 2" in output
-            assert "line 3" in output
-            assert '<block lines="2-3" score="0.7000">' in output
-        finally:
-            temp_path.unlink()
+        assert "line 7" in output
+        assert "line 8" in output
+        assert '<block lines="7-8" score="0.9000">' in output
+        assert "line 2" in output
+        assert "line 3" in output
+        assert '<block lines="2-3" score="0.7000">' in output
 
     def test_format_truncated_file(self) -> None:
-        """Test formatting when file is shorter than block end_line indicates."""
-        with NamedTemporaryFile(mode="w", delete=False, suffix=".log") as f:
-            f.write("line 1\n")
-            f.write("line 2\n")
-            f.write("line 3\n")
-            temp_path = Path(f.name)
+        """Test formatting when lines don't cover block end_line."""
+        lines = [(1, "line 1"), (2, "line 2"), (3, "line 3")]
+        blocks = [
+            MergedBlock(start_line=2, end_line=10, original_windows=(0,), max_score=0.8),
+        ]
 
-        try:
-            from cordon.core.types import MergedBlock
+        formatter = OutputFormatter()
+        output = formatter.format_blocks(blocks, lines)
 
-            blocks = [
-                MergedBlock(start_line=2, end_line=10, original_windows=(0,), max_score=0.8),
-            ]
-
-            formatter = OutputFormatter()
-            output = formatter.format_blocks(blocks, temp_path)
-
-            assert "line 2" in output
-            assert "line 3" in output
-            assert "</anomalies>" in output
-        finally:
-            temp_path.unlink()
+        assert "line 2" in output
+        assert "line 3" in output
+        assert "</anomalies>" in output
 
     def test_format_unsorted_block_input(self) -> None:
         """Test that blocks passed in unsorted order are output in correct order."""
-        with NamedTemporaryFile(mode="w", delete=False, suffix=".log") as f:
-            for i in range(1, 11):
-                f.write(f"line {i}\n")
-            temp_path = Path(f.name)
+        lines = [(i, f"line {i}") for i in range(1, 11)]
+        blocks = [
+            MergedBlock(start_line=7, end_line=8, original_windows=(1,), max_score=0.9),
+            MergedBlock(start_line=2, end_line=3, original_windows=(0,), max_score=0.7),
+        ]
 
-        try:
-            from cordon.core.types import MergedBlock
+        formatter = OutputFormatter()
+        output = formatter.format_blocks(blocks, lines)
 
-            blocks = [
-                MergedBlock(start_line=7, end_line=8, original_windows=(1,), max_score=0.9),
-                MergedBlock(start_line=2, end_line=3, original_windows=(0,), max_score=0.7),
-            ]
-
-            formatter = OutputFormatter()
-            output = formatter.format_blocks(blocks, temp_path)
-
-            block_2_pos = output.index('<block lines="2-3"')
-            block_7_pos = output.index('<block lines="7-8"')
-            assert block_2_pos < block_7_pos
-            assert "line 2" in output
-            assert "line 7" in output
-        finally:
-            temp_path.unlink()
+        block_2_pos = output.index('<block lines="2-3"')
+        block_7_pos = output.index('<block lines="7-8"')
+        assert block_2_pos < block_7_pos
+        assert "line 2" in output
+        assert "line 7" in output


### PR DESCRIPTION
## Summary

- Extract shared device detection utility into `cordon.core.device` with `detect_device()` and `check_cuda_compatibility()`, eliminating duplicated logic between scorer and transformer embedder
- Fix bug where explicitly requesting `--device cuda` when CUDA is unavailable silently proceeded instead of raising an error
- Unify `_score_windows_gpu` and `_score_windows_cpu_pytorch` into a single `_score_windows` method parameterized by device, eliminating ~170 lines of duplication
- Add `F.normalize()` to guarantee embedding normalization regardless of backend
- Fix `torch.cat` inefficiency in k-NN chunk loop: pre-filter chunk distances to top-k before concatenating, reducing intermediate memory allocation ~2000x
- Vectorize per-element `np.mean` scoring loop (10-50x faster for score computation)
- Defer `import torch` to avoid 1-3s startup penalty for `cordon --help`
- Extract magic numbers to named constants
- Log warning instead of silently swallowing CUDA batch size detection errors
- Remove unused `embedding` field from `ScoredWindow`, saving ~74MB peak memory
- Cache vectorizer in `SemanticLogAnalyzer.__init__` to avoid reloading the model on every file
- Pass ingested lines to formatter instead of re-reading the file (eliminates redundant I/O)
- Add `total_lines` field to `AnalysisResult`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated anomaly scoring implementation for improved performance and efficiency
  * Streamlined device detection with automatic GPU compatibility validation
  * Analysis results now include total line count

* **Tests**
  * Added comprehensive device detection and GPU compatibility test coverage

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/calebevans/cordon/pull/34?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->